### PR TITLE
Fix real-time room updates when players join

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -59,3 +59,12 @@ export async function getState(room_id: string, x_user_id?: string): Promise<any
   if (!res.ok) throw new Error('Failed to load game state')
   return await res.json()
 }
+
+/** Старт игры */
+export async function startGame(room_id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/game/start/${room_id}`, { method: 'POST' })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || 'Failed to start game')
+  }
+}


### PR DESCRIPTION
## Summary
- reuse the resilient room channel in the main app so room state updates are delivered when players join
- expose a `send` helper on the room channel so the UI can fire websocket actions with reconnect/polling fallback
- add a missing `startGame` API wrapper that the controls component relies on

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d160fc83e08332b040aeec2d77cead