### PR TITLE
Add configurable table support and redesign game UI

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -33,3 +33,28 @@ def test_create_join_start_flow():
     assert st["started"] is True
     assert isinstance(st.get("hands"), list)
     assert st["variant"]["players_max"] == 2
+    assert st["scores"]["userA"] == 0
+    assert st["scores"]["userB"] == 0
+
+
+def test_create_with_custom_config():
+    headers = {"x-user-id":"host","x-user-name":"Host","x-user-avatar":""}
+    payload = {
+        "room_name": "Custom",
+        "config": {
+            "maxPlayers": 4,
+            "discardVisibility": "faceDown",
+            "enableFourEnds": True,
+            "turnTimeoutSec": 60,
+        },
+    }
+    r = client.post("/api/game/create", json=payload, headers=headers)
+    assert r.status_code == 200
+    room_id = r.json()["room_id"]
+
+    state = client.get(f"/api/game/state/{room_id}", headers=headers)
+    assert state.status_code == 200
+    data = state.json()
+    assert data["config"]["maxPlayers"] == 4
+    assert data["config"]["discardVisibility"] == "faceDown"
+    assert data["variant"]["key"] == "custom"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,6 +106,16 @@ export default function App(){
     sendAction({ type: 'draw', player_id: user.id })
   }
 
+  function onPass(){
+    if(!user || !roomId) return
+    sendAction({ type: 'pass', player_id: user.id })
+  }
+
+  function onDiscard(){
+    if(!user || !roomId) return
+    sendAction({ type: 'discard', player_id: user.id })
+  }
+
   // рендер
   return (
     <div className="app">
@@ -142,30 +152,31 @@ export default function App(){
       )}
 
       {screen === 'room' && state && (
-        <div className="page-wrap">
-          <div className="room-top">
-            <div className="badge strong">{user?.name}</div>
-            <div className="badge">Комната: {state.room_id}</div>
-            <div className="badge">
-              Игроков: {state.players.length}/
-              {state.config?.maxPlayers ?? state.variant?.players_max ?? state.players.length}
+        <div className="game-page">
+          <header className="game-hud">
+            <div className="hud-primary">
+              <div className="hud-title">{state.room_name}</div>
+              <div className="hud-sub">Комната #{state.room_id}</div>
             </div>
-            <div className="badge">Колода: {state.deck_count}</div>
-            <div className="badge">Ход: {state.turn_player_id?.slice(0,4) || '—'}</div>
-            {state.config && (
-              <div className="badge">
-                Таймер: {state.config.turnTimeoutSec} с · {state.config.discardVisibility === 'open' ? 'открытый сброс' : 'закрытый сброс'}
-              </div>
-            )}
-          </div>
+            <div className="hud-stats">
+              <span className="pill">Игроков {state.players.length}/{state.config?.maxPlayers ?? state.variant?.players_max ?? state.players.length}</span>
+              <span className="pill">Колода {state.deck_count}</span>
+              <span className="pill">Ход: {state.turn_player_id?.slice(0, 4) || '—'}</span>
+              {state.config && (
+                <span className="pill">
+                  Таймер {state.config.turnTimeoutSec} с · {state.config.discardVisibility === 'open' ? 'открытый' : 'закрытый'} сброс
+                </span>
+              )}
+            </div>
+          </header>
 
-          <TableView table={state.table_cards} trump={state.trump} trumpCard={state.trump_card} />
+          <TableView state={state} meId={user?.id} />
 
-          <Controls state={state} onDraw={onDraw} />
+          <Controls state={state} onDraw={onDraw} onPass={onPass} onDiscard={onDiscard} />
 
           {state.hands && (
-            <div>
-              <h4>Твоя рука</h4>
+            <div className="hand-wrap">
+              <h4 className="hand-title">Твои карты</h4>
               <Hand cards={state.hands} onPlay={onPlay} />
             </div>
           )}

--- a/frontend/src/components/CardView.tsx
+++ b/frontend/src/components/CardView.tsx
@@ -8,9 +8,13 @@ const suitToEmoji: Record<string, string> = {
 
 export default function CardView({ card }: { card: Card }) {
   const suit = suitToEmoji[card.suit] ?? card.suit
+  const rankMap: Record<number, string> = { 11: 'В', 12: 'Д', 13: 'К', 14: 'Т' }
+  const rank = rankMap[card.rank] ?? card.rank
+  const isRed = card.suit === '♥' || card.suit === '♦'
+  const label = `${rank}${suit}`
   return (
-    <div className="card">
-      <div className="card-rank">{card.rank}</div>
+    <div className={`card ${isRed ? 'red' : ''}`} title={label} aria-label={label}>
+      <div className="card-rank">{rank}</div>
       <div className="card-suit">{suit}</div>
     </div>
   )

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -4,13 +4,18 @@ import { startGame } from '../api'
 
 export default function Controls({
   state,
-  onDraw
+  onDraw,
+  onPass,
+  onDiscard
 }:{
   state?: GameState
   onDraw: ()=>void
+  onPass: ()=>void
+  onDiscard: ()=>void
 }){
-  const requiredPlayers = state?.variant?.players_min ?? state?.config?.maxPlayers ?? 2
+  const requiredPlayers = state?.config?.maxPlayers ?? state?.variant?.players_min ?? 2
   const canStart = !!state && !state.started && state.players.length >= requiredPlayers
+  const canAct = !!state?.started
   return (
     <div className="controls">
       <button
@@ -20,6 +25,8 @@ export default function Controls({
       >
         Старт
       </button>
+      <button className="button secondary" disabled={!canAct} onClick={onPass}>Отбиться</button>
+      <button className="button secondary" disabled={!canAct} onClick={onDiscard}>Сбросить карты</button>
       <button className="button secondary" onClick={onDraw}>Добор</button>
     </div>
   )

--- a/frontend/src/components/Hand.tsx
+++ b/frontend/src/components/Hand.tsx
@@ -72,6 +72,7 @@ export default function Hand({
         <div
           key={`${c.suit}${c.rank}-${i}`}
           className="hand-card"
+          style={{ animationDelay: `${i * 60}ms` }}
           onPointerDown={(e)=>attachDrag(e, c)}
           onClick={()=>onPlay(c)}
         >

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,37 +1,140 @@
-import React from 'react'
-import type { Card } from '../types'
+import React, { useMemo } from 'react'
+import type { Card, GameState, Player } from '../types'
 import CardView from './CardView'
 
-type Pair = { a: Card; c?: Card }
+type TablePair = { attack: Card; defend?: Card }
 
-export default function TableView({
-  table,
-  trump,
-  trumpCard,
-}:{
-  table?: Pair[]
-  trump?: string
-  trumpCard?: Card
+type Props = {
+  state: GameState
+  meId?: string
+}
+
+function pairCards(cards: Card[] = []): TablePair[] {
+  const pairs: TablePair[] = []
+  for (let i = 0; i < cards.length; i += 2) {
+    const attack = cards[i]
+    const defend = cards[i + 1]
+    if (attack) {
+      pairs.push({ attack, defend })
+    }
+  }
+  return pairs
+}
+
+function sortPlayers(players: Player[], meId?: string): Player[] {
+  if (!players.length) return []
+  const ordered = [...players].sort((a, b) => (a.seat ?? 0) - (b.seat ?? 0))
+  if (!meId) return ordered
+  const myIndex = ordered.findIndex(p => p.id === meId)
+  if (myIndex === -1) return ordered
+  return ordered.slice(myIndex).concat(ordered.slice(0, myIndex))
+}
+
+function OpponentBadge({ player, isTurn, score }: {
+  player: Player
+  isTurn: boolean
+  score?: number
 }) {
+  return (
+    <div className={`opponent-badge ${isTurn ? 'turn' : ''}`}>
+      <div className="opponent-name">{player.name}</div>
+      <div className="opponent-meta">
+        <span className="pill">Счёт: {score ?? 0}</span>
+      </div>
+    </div>
+  )
+}
+
+export default function TableView({ state, meId }: Props) {
+  const pairs = useMemo(() => pairCards(state.table_cards), [state.table_cards])
+  const orderedPlayers = useMemo(() => sortPlayers(state.players, meId), [state.players, meId])
+  const me = orderedPlayers[0]?.id === meId ? orderedPlayers[0] : undefined
+  const opponents = me ? orderedPlayers.slice(1) : orderedPlayers
+  const top = opponents[0]
+  const right = opponents[1]
+  const left = opponents[2]
+
   const suitToEmoji: Record<string, string> = { S:'♠️', H:'♥️', D:'♦️', C:'♣️', s:'♠️', h:'♥️', d:'♦️', c:'♣️' }
-  const trumpEmoji = trump ? (suitToEmoji[trump] ?? trump) : ''
+  const trumpEmoji = state.trump ? (suitToEmoji[state.trump] ?? state.trump) : ''
+  const scores = state.scores || {}
 
   return (
-    <div className="table-area">
-      <div id="drop-zone" className="drop-zone" />
-      <div className="pairs">
-        {(table || []).map((p, idx)=>(
-          <div className="pair" key={idx}>
-            <CardView card={p.a} />
-            {p.c ? <CardView card={p.c} /> : <div className="cover-slot" />}
+    <div className="table-layout">
+      <div className="score-row">
+        {orderedPlayers.map(player => (
+          <div
+            key={player.id}
+            className={`score-chip ${state.turn_player_id === player.id ? 'active' : ''}`}
+          >
+            <span className="score-name">{player.name}</span>
+            <span className="score-value">{scores[player.id] ?? 0}</span>
           </div>
         ))}
       </div>
 
-      <div className="trump-panel">
-        <div className="trump-title">Козырь {trumpEmoji}</div>
-        {trumpCard && <CardView card={trumpCard} />}
+      <div className="board-grid">
+        <div className="seat seat-top">
+          {top && (
+            <OpponentBadge
+              player={top}
+              isTurn={state.turn_player_id === top.id}
+              score={scores[top.id]}
+            />
+          )}
+        </div>
+        <div className="seat seat-left">
+          {left && (
+            <OpponentBadge
+              player={left}
+              isTurn={state.turn_player_id === left.id}
+              score={scores[left.id]}
+            />
+          )}
+        </div>
+
+        <div className="table-center">
+          <div className="table-pairs">
+            {pairs.length === 0 && <div className="table-placeholder">Ходите картой</div>}
+            {pairs.map((pair, idx) => (
+              <div className="table-pair" key={`${pair.attack.suit}${pair.attack.rank}-${idx}`}>
+                <div className="table-card attack">
+                  <CardView card={pair.attack} />
+                </div>
+                <div className={`table-card defend ${pair.defend ? 'visible' : 'ghost'}`}>
+                  {pair.defend ? <CardView card={pair.defend} /> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="trump-info">
+            <div className="trump-label">Козырь {trumpEmoji}</div>
+            <div className={`trump-card ${state.trump_card ? '' : 'ghost'}`}>
+              {state.trump_card ? <CardView card={state.trump_card} /> : <span>—</span>}
+            </div>
+            <div className="deck-counter">Колода: {state.deck_count}</div>
+          </div>
+        </div>
+
+        <div className="seat seat-right">
+          {right && (
+            <OpponentBadge
+              player={right}
+              isTurn={state.turn_player_id === right.id}
+              score={scores[right.id]}
+            />
+          )}
+        </div>
       </div>
+
+      {me && (
+        <div className="player-badge">
+          <div className="player-name">{me.name}</div>
+          <div className="player-meta">
+            <span className="pill">Вы</span>
+            <span className="pill">Счёт: {scores[me.id] ?? 0}</span>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/__tests__/Card.test.tsx
+++ b/frontend/src/components/__tests__/Card.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react'
-import CardView from '../Card'
+import { expect, test } from 'vitest'
+import CardView from '../CardView'
 
 test('renders face values and suits', () => {
   render(<CardView card={{ suit: '♠', rank: 14 }} />)
-  expect(screen.getByTitle('A♠')).toBeInTheDocument()
+  expect(screen.getByTitle('Т♠')).toBeInTheDocument()
 })
 
 test('renders number ranks', () => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -216,3 +216,61 @@ body, .app{
   from{ transform: translateY(8px); opacity: .0; }
   to  { transform: none; opacity: 1; }
 }
+
+/* ===== Game room ===== */
+.game-page{ display:grid; gap:16px; padding:12px; }
+.game-hud{ display:flex; flex-direction:column; gap:8px; padding:12px; border:1px solid var(--border); border-radius:16px; background:var(--card); }
+.hud-primary{ display:grid; gap:2px; }
+.hud-title{ font-size:20px; font-weight:800; }
+.hud-sub{ font-size:12px; color:var(--muted); }
+.hud-stats{ display:flex; flex-wrap:wrap; gap:8px; }
+.pill{ display:inline-flex; align-items:center; gap:4px; padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.06); color:var(--muted); font-size:12px; }
+html[data-theme="dark"] .pill{ background:rgba(255,255,255,.08); color:var(--fg); }
+
+.table-layout{ display:grid; gap:16px; padding:12px; border:1px solid var(--border); border-radius:20px; background:var(--card); box-shadow:0 12px 28px rgba(0,0,0,.12); }
+.score-row{ display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
+.score-chip{ padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.05); color:var(--muted); font-size:12px; display:flex; gap:6px; align-items:center; transition:all .2s ease; }
+.score-chip.active{ background:var(--primary); color:var(--primary-fg); }
+.score-name{ font-weight:600; }
+.score-value{ font-weight:700; }
+
+.board-grid{ display:grid; grid-template-columns:120px 1fr 120px; grid-template-rows:auto auto; gap:12px; align-items:center; }
+.seat{ display:flex; justify-content:center; align-items:center; min-height:80px; }
+.seat-top{ grid-column:1 / span 3; justify-content:center; }
+.seat-left{ grid-column:1 / span 1; grid-row:2; justify-content:flex-start; }
+.seat-right{ grid-column:3 / span 1; grid-row:2; justify-content:flex-end; }
+.table-center{ grid-column:2; grid-row:2; display:flex; align-items:center; justify-content:center; gap:24px; position:relative; }
+
+.table-pairs{ display:flex; flex-wrap:wrap; gap:18px; min-height:130px; }
+.table-pair{ position:relative; width:110px; height:120px; }
+.table-card{ position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); transition:transform .3s ease, opacity .3s ease; }
+.table-card.attack{ transform:translate(-50%, -50%) rotate(-4deg); animation:drop-attack .3s ease; }
+.table-card.defend{ opacity:0; transform:translate(-50%, -50%) rotate(10deg); }
+.table-card.defend.visible{ opacity:1; animation:cover-card .3s ease forwards; }
+.table-card.defend.ghost{ opacity:.2; border:1px dashed var(--border); border-radius:10px; width:68px; height:96px; display:grid; place-items:center; }
+.table-card > .card{ box-shadow:0 8px 16px rgba(0,0,0,.15); }
+
+.table-placeholder{ padding:16px 20px; border-radius:12px; border:1px dashed var(--border); color:var(--muted); font-size:12px; }
+
+.trump-info{ display:grid; gap:6px; text-align:center; }
+.trump-label{ font-size:12px; font-weight:700; }
+.trump-card{ width:68px; height:96px; display:grid; place-items:center; border-radius:12px; border:1px solid var(--border); background:var(--bg); box-shadow:0 4px 14px rgba(0,0,0,.15); }
+.trump-card.ghost{ color:var(--muted); }
+.deck-counter{ font-size:12px; color:var(--muted); }
+
+.opponent-badge{ display:grid; gap:4px; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:rgba(0,0,0,.04); min-width:120px; text-align:center; transition:transform .2s ease; }
+.opponent-badge.turn{ transform:translateY(-4px); border-color:var(--primary); box-shadow:0 0 0 3px color-mix(in srgb, var(--primary) 20%, transparent); }
+.opponent-name{ font-weight:700; }
+.opponent-meta{ display:flex; flex-direction:column; gap:4px; font-size:11px; color:var(--muted); }
+
+.player-badge{ justify-self:center; display:flex; gap:8px; align-items:center; padding:10px 16px; border-radius:999px; border:1px solid var(--border); background:var(--card); font-weight:700; }
+.player-meta{ display:flex; gap:6px; }
+
+.hand-wrap{ display:grid; gap:8px; }
+.hand-title{ margin:0; font-size:14px; font-weight:700; }
+
+@keyframes drop-attack{ from{ transform:translate(-50%, -70%) rotate(-10deg); opacity:0; } to{ transform:translate(-50%, -50%) rotate(-4deg); opacity:1; } }
+@keyframes cover-card{ from{ transform:translate(-50%, -30%) rotate(20deg); opacity:0; } to{ transform:translate(-50%, -50%) rotate(10deg); opacity:1; } }
+
+.card.red .card-rank,
+.card.red .card-suit{ color:#d33; }

--- a/frontend/src/test.setup.ts
+++ b/frontend/src/test.setup.ts
@@ -1,1 +1,4 @@
-import '@testing-library/jest-dom'
+import { expect } from 'vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,4 +24,5 @@ export type GameState = {
   hands?: Card[]
   turn_player_id?: string
   winner_id?: string
+  scores?: Record<string, number>
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,4 +9,8 @@ const base =
 export default defineConfig({
   plugins: [react()],
   base,
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test.setup.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- allow custom table configuration to be passed from the client, persist it in room state, and broadcast scores and new actions over HTTP and WebSocket APIs
- extend the game room to track simple score counters, support discard/pass actions, and expose config metadata in lobby summaries and tests
- rebuild the game screen with a Durak-style layout, card animations, scoreboard, action buttons, themed cards, and update Vitest configuration with supporting tests

## Testing
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ab2876888332933a09495ed31e85