### PR TITLE
Implement Bura rules and refresh gameplay UI

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -1,45 +1,108 @@
 from __future__ import annotations
+
 import random
-from typing import Dict, List, Optional
-from models import Card, GameVariant, Player, GameState, TableConfig
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
 
-SUITS = ["♠","♥","♦","♣"]
-RANKS = [6,7,8,9,10,11,12,13,14]
+from models import (
+    Announcement,
+    Card,
+    GameState,
+    GameVariant,
+    Player,
+    TableConfig,
+    TrickPlay,
+    TrickState,
+)
 
-VARIANTS: Dict[str, GameVariant] = {
-    "classic_3p": GameVariant(key="classic_3p", title="Классика (3 игрока)", players_min=3, players_max=3,
-                              description="36 карт, козырь последняя карта. Игроки добирают до 3 карт."),
-    "classic_2p": GameVariant(key="classic_2p", title="Классика (2 игрока)", players_min=2, players_max=2,
-                              description="36 карт, на двоих. Добор до 3 карт."),
-    "with_sevens": GameVariant(key="with_sevens", title="С семёрками (3 игрока)", players_min=3, players_max=3,
-                              description="Особые правила для 7 в колоде."),
-    "with_draw": GameVariant(key="with_draw", title="С добором (2–4 игрока)", players_min=2, players_max=4,
-                              description="Гибка версия с добором из колоды до 3 карт."),
+SUITS = ["♠", "♥", "♦", "♣"]
+RANKS = [6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+CARD_POINTS: Dict[int, int] = {
+    14: 11,  # Ace
+    10: 10,
+    13: 4,   # King
+    12: 3,   # Queen
+    11: 2,   # Jack
 }
+
+RANK_STRENGTH: Dict[int, int] = {rank: idx for idx, rank in enumerate(RANKS)}
+
+COMBINATION_NAMES = {
+    "bura": "Бура",
+    "molodka": "Молодка",
+    "moscow": "Москва",
+    "four_ends": "4 конца",
+}
+
+
+def _make_deck() -> List[Card]:
+    return [Card(suit=suit, rank=rank) for suit in SUITS for rank in RANKS]
+
+
+@dataclass
+class _TrickInternal:
+    leader_id: str
+    required_count: int
+    owner_id: str
+    owner_cards: List[Card]
+    captured_cards: List[Card] = field(default_factory=list)
+    plays: List[TrickPlay] = field(default_factory=list)
+
+    def to_public(self) -> TrickState:
+        return TrickState(
+            leader_id=self.leader_id,
+            owner_id=self.owner_id,
+            required_count=self.required_count,
+            plays=list(self.plays),
+        )
+
 
 class Room:
     def __init__(self, room_id: str, room_name: str, variant: GameVariant, config: Optional[TableConfig] = None):
         self.id = room_id
         self.name = room_name
         self.variant = variant
-        self.config = config
+        self.config = config or TableConfig()
         self.players: List[Player] = []
         self.started = False
+
         self.deck: List[Card] = []
         self.trump: Optional[str] = None
         self.trump_card: Optional[Card] = None
         self.hands: Dict[str, List[Card]] = {}
-        self.table: List[Card] = []
+        self.taken_cards: Dict[str, List[Card]] = {}
+        self.discard_pile: List[Card] = []
+        self.announcements: List[Announcement] = []
+        self.declared_combos: Dict[str, set[str]] = {}
+
         self.turn_idx: int = 0
+        self.turn_deadline: Optional[float] = None
+        self.current_trick: Optional[_TrickInternal] = None
+        self.last_trick_winner_id: Optional[str] = None
+        self.dealer_idx: int = 0
+
+        self.round_number: int = 0
+        self.round_active: bool = False
+        self.round_summary: Dict[str, int] = {}
+
         self.winner_id: Optional[str] = None
+        self.match_over: bool = False
+        self.winners: List[str] = []
+        self.losers: List[str] = []
+
         self.scores: Dict[str, int] = {}
 
+    # ------------------------------------------------------------------
+    # Lobby management
+    # ------------------------------------------------------------------
     def add_player(self, p: Player):
         if self.started:
             raise ValueError("Game already started")
         if any(x.id == p.id for x in self.players):
             return
-        max_players = self.config.max_players if self.config else self.variant.players_max
+        max_players = self.config.max_players or self.variant.players_max
         if len(self.players) >= max_players:
             raise ValueError("Room full")
         p.seat = len(self.players)
@@ -50,100 +113,338 @@ class Room:
     def remove_player(self, player_id: str):
         self.players = [p for p in self.players if p.id != player_id]
         self.hands.pop(player_id, None)
+        self.taken_cards.pop(player_id, None)
         self.scores.pop(player_id, None)
+        self.declared_combos.pop(player_id, None)
         if self.players:
             self.turn_idx %= len(self.players)
         else:
             self.started = False
+            self.round_active = False
 
+    # ------------------------------------------------------------------
+    # Match lifecycle
+    # ------------------------------------------------------------------
     def start(self):
         if self.started:
             return
         min_players = self.variant.players_min
-        if self.config:
-            min_players = min(min_players, self.config.max_players)
-            min_players = max(2, min_players)
+        max_players = self.config.max_players or self.variant.players_max
+        min_players = max(2, min(min_players, max_players))
         if len(self.players) < min_players:
             raise ValueError("Not enough players")
-        self.deck = [Card(suit=s, rank=r) for s in SUITS for r in RANKS]
+        self.started = True
+        self.match_over = False
+        self.round_summary = {}
+        self.winners = []
+        self.losers = []
+        self.turn_deadline = None
+        self.last_trick_winner_id = None
+        self.dealer_idx = random.randrange(len(self.players))
+        self.round_number = 0
+        self._start_new_round(initial=True)
+
+    def _start_new_round(self, *, initial: bool):
+        if not self.players:
+            return
+        self.round_number += 1
+        self.round_active = True
+        self.deck = _make_deck()
         random.shuffle(self.deck)
-        self.trump_card = self.deck[-1]
-        self.trump = self.trump_card.suit
-        for pl in self.players:
-            self.hands[pl.id] = []
-        for _ in range(3):
+        self.trump_card = self.deck[-1] if self.deck else None
+        self.trump = self.trump_card.suit if self.trump_card else None
+        self.discard_pile = []
+        self.announcements = []
+        self.declared_combos = {p.id: set() for p in self.players}
+        self.taken_cards = {p.id: [] for p in self.players}
+        self.hands = {p.id: [] for p in self.players}
+        self.current_trick = None
+
+        for _ in range(4):
             for pl in self.players:
                 if self.deck:
                     self.hands[pl.id].append(self.deck.pop(0))
-        self.started = True
-        self.turn_idx = 0
-        self.table.clear()
 
-    def to_state(self, me_id: Optional[str]) -> GameState:
-        return GameState(
-            room_id=self.id, room_name=self.name, started=self.started, variant=self.variant,
-            config=self.config,
-            players=self.players, me=next((p for p in self.players if p.id == me_id), None),
-            trump=self.trump, trump_card=self.trump_card, table_cards=list(self.table),
-            deck_count=len(self.deck), hands=self.hands.get(me_id),
-            turn_player_id=self.players[self.turn_idx].id if self.started and self.players else None,
-            winner_id=self.winner_id,
-            scores=self.scores,
-        )
+        if initial or not self.last_trick_winner_id:
+            self.turn_idx = (self.dealer_idx + 1) % len(self.players)
+        else:
+            self.turn_idx = self._player_index(self.last_trick_winner_id)
+        self._refresh_deadline()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _player_index(self, player_id: str) -> int:
+        for idx, player in enumerate(self.players):
+            if player.id == player_id:
+                return idx
+        raise ValueError("Unknown player")
 
     def current_player_id(self) -> Optional[str]:
         if not self.players:
             return None
         return self.players[self.turn_idx].id
 
+    def _refresh_deadline(self):
+        if not self.round_active:
+            self.turn_deadline = None
+            return
+        timeout = self.config.turn_timeout_sec
+        self.turn_deadline = time.time() + timeout if timeout else None
+
+    def _check_timeout(self):
+        if not self.round_active or not self.turn_deadline:
+            return
+        if time.time() <= self.turn_deadline:
+            return
+        offender = self.current_player_id()
+        if not offender:
+            return
+        penalties = {p.id: 0 for p in self.players}
+        penalties[offender] = 6
+        self.round_summary = {p.id: 0 for p in self.players}
+        self._finalize_round(penalties)
+
     def _beats(self, a: Card, b: Card) -> bool:
-        if a.suit == b.suit and a.rank > b.rank: return True
-        if a.suit == self.trump and b.suit != self.trump: return True
+        if a.suit == b.suit:
+            return RANK_STRENGTH[a.rank] > RANK_STRENGTH[b.rank]
+        if a.suit == self.trump and b.suit != self.trump:
+            return True
         return False
 
-    def play(self, pid: str, card: Card):
-        if pid != self.current_player_id(): raise ValueError("Not your turn")
-        hand = self.hands.get(pid, [])
-        for i,c in enumerate(hand):
-            if c.suit == card.suit and c.rank == card.rank:
-                self.table.append(hand.pop(i))
-                self.turn_idx = (self.turn_idx + 1) % len(self.players)
-                return
-        raise ValueError("Card not in hand")
+    def _cards_fully_beat(self, challenger: Iterable[Card], owner_cards: Iterable[Card]) -> bool:
+        challenger_cards = list(challenger)
+        remaining = challenger_cards.copy()
+        for owner_card in owner_cards:
+            idx = next((i for i, card in enumerate(remaining) if self._beats(card, owner_card)), None)
+            if idx is None:
+                return False
+            remaining.pop(idx)
+        return True
 
-    def cover(self, pid: str, card: Card):
-        if pid != self.current_player_id(): raise ValueError("Not your turn")
-        if not self.table: raise ValueError("Nothing to cover")
-        last = self.table[-1]
-        if not self._beats(card, last): raise ValueError("Card does not cover")
-        hand = self.hands.get(pid, [])
-        for i,c in enumerate(hand):
-            if c.suit == card.suit and c.rank == card.rank:
-                self.table.append(hand.pop(i))
-                self.turn_idx = (self.turn_idx + 1) % len(self.players)
-                return
-        raise ValueError("Card not in hand")
-
-    def draw_up(self):
-        for pl in self.players:
-            while len(self.hands[pl.id]) < 3 and self.deck:
-                self.hands[pl.id].append(self.deck.pop(0))
-
-    def discard(self, pid: Optional[str] = None):
-        if pid and pid != self.current_player_id():
-            raise ValueError("Not your turn")
-        self.table.clear()
-
-    def pass_turn(self, pid: Optional[str] = None):
-        if pid and pid != self.current_player_id():
-            raise ValueError("Not your turn")
-        if not self.players:
+    def _draw_up_from_deck(self, winner_id: str):
+        if not self.deck:
             return
+        start_idx = self._player_index(winner_id)
+        total_players = len(self.players)
+        for offset in range(total_players):
+            pid = self.players[(start_idx + offset) % total_players].id
+            while len(self.hands[pid]) < 4 and self.deck:
+                self.hands[pid].append(self.deck.pop(0))
+
+    def _round_finished(self) -> bool:
+        return all(len(hand) == 0 for hand in self.hands.values()) and not self.deck
+
+    def _calculate_round_result(self) -> Dict[str, int]:
+        return {
+            pid: sum(CARD_POINTS.get(card.rank, 0) for card in cards)
+            for pid, cards in self.taken_cards.items()
+        }
+
+    def _finalize_round(self, penalties: Dict[str, int]):
+        for pid, value in penalties.items():
+            self.scores[pid] = self.scores.get(pid, 0) + value
+        self.round_active = False
+        self.current_trick = None
+        self.turn_deadline = None
+        self.match_over = any(score >= 12 for score in self.scores.values())
+        if self.match_over:
+            self.losers = [pid for pid, score in self.scores.items() if score >= 12]
+            self.winners = [pid for pid in self.scores.keys() if pid not in self.losers]
+            self.winner_id = self.winners[0] if len(self.winners) == 1 else None
+            self.started = False
+            return
+        self.winner_id = None
+        self._start_new_round(initial=False)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def declare_combination(self, player_id: str, combo_key: str):
+        self._check_timeout()
+        if not self.round_active:
+            raise ValueError("Round is not active")
+        if self.current_trick is not None:
+            raise ValueError("Cannot declare after trick has started")
+        if combo_key not in COMBINATION_NAMES:
+            raise ValueError("Unknown combination")
+        if combo_key == "four_ends" and not self.config.enable_four_ends:
+            raise ValueError("Combination not enabled")
+        allowed = self.declared_combos.setdefault(player_id, set())
+        if combo_key in allowed:
+            raise ValueError("Combination already declared")
+        cards = self._find_combination_cards(player_id, combo_key)
+        if not cards:
+            raise ValueError("Combination cards not present")
+        announcement = Announcement(player_id=player_id, combo=combo_key, cards=cards)
+        self.announcements.append(announcement)
+        allowed.add(combo_key)
+
+    def _find_combination_cards(self, player_id: str, combo_key: str) -> List[Card]:
+        hand = list(self.hands.get(player_id) or [])
+        if not hand:
+            return []
+        if combo_key == "bura" and self.trump:
+            trumps = [card for card in hand if card.suit == self.trump]
+            if len(trumps) >= 4:
+                return trumps[:4]
+            return []
+        if combo_key == "molodka":
+            for suit in SUITS:
+                same_suit = [card for card in hand if card.suit == suit]
+                if len(same_suit) >= 4:
+                    return same_suit[:4]
+            return []
+        if combo_key == "moscow":
+            aces = [card for card in hand if card.rank == 14]
+            if len(aces) >= 3 and any(card.suit == self.trump for card in aces):
+                return aces[:3]
+            return []
+        if combo_key == "four_ends":
+            tens = [card for card in hand if card.rank == 10]
+            if len(tens) == 4:
+                return tens
+            aces = [card for card in hand if card.rank == 14]
+            if len(aces) == 4:
+                return aces
+            return []
+        return []
+
+    def play(self, player_id: str, cards_payload: List[dict | Card]):
+        self._check_timeout()
+        if not self.started or not self.round_active:
+            raise ValueError("Round not active")
+        if player_id != self.current_player_id():
+            raise ValueError("Not your turn")
+        if not isinstance(cards_payload, list) or not cards_payload:
+            raise ValueError("Must play one or more cards")
+
+        hand = self.hands.get(player_id, [])
+        cards = [card if isinstance(card, Card) else Card.model_validate(card) for card in cards_payload]
+
+        for card in cards:
+            if not any(c.suit == card.suit and c.rank == card.rank for c in hand):
+                raise ValueError("Card not in hand")
+
+        if self.current_trick is None:
+            if len(cards) not in (1, 2, 3):
+                raise ValueError("Leader must play 1, 2 or 3 cards")
+            if len({card.suit for card in cards}) != 1:
+                raise ValueError("Leader cards must share suit")
+            min_available = min(len(self.hands[p.id]) for p in self.players)
+            if len(cards) > min_available:
+                raise ValueError("Other players do not have enough cards")
+            self.current_trick = _TrickInternal(
+                leader_id=player_id,
+                required_count=len(cards),
+                owner_id=player_id,
+                owner_cards=list(cards),
+            )
+            self.current_trick.plays.append(TrickPlay(player_id=player_id, cards=list(cards), outcome="lead"))
+        else:
+            trick = self.current_trick
+            if len(cards) != trick.required_count:
+                raise ValueError("Must play the required number of cards")
+            if self._cards_fully_beat(cards, trick.owner_cards):
+                trick.captured_cards.extend(trick.owner_cards)
+                trick.owner_id = player_id
+                trick.owner_cards = list(cards)
+                trick.plays.append(TrickPlay(player_id=player_id, cards=list(cards), outcome="beat"))
+            else:
+                self.discard_pile.extend(cards)
+                trick.plays.append(TrickPlay(player_id=player_id, cards=list(cards), outcome="discard"))
+
+        for card in cards:
+            idx = next(i for i, owned in enumerate(hand) if owned.suit == card.suit and owned.rank == card.rank)
+            hand.pop(idx)
+
         self.turn_idx = (self.turn_idx + 1) % len(self.players)
+
+        if self.current_trick and len(self.current_trick.plays) == len(self.players):
+            self._complete_trick()
+        else:
+            self._refresh_deadline()
+
+    def _complete_trick(self):
+        trick = self.current_trick
+        if not trick:
+            return
+        winner_id = trick.owner_id
+        cards_for_winner = trick.captured_cards + trick.owner_cards
+        self.taken_cards[winner_id].extend(cards_for_winner)
+        self.last_trick_winner_id = winner_id
+        self.current_trick = None
+        self.turn_idx = self._player_index(winner_id)
+        self._draw_up_from_deck(winner_id)
+        if self._round_finished():
+            points = self._calculate_round_result()
+            self.round_summary = points
+            penalties = self._calculate_penalties(points)
+            self._finalize_round(penalties)
+        else:
+            self._refresh_deadline()
+
+    def _calculate_penalties(self, points: Dict[str, int]) -> Dict[str, int]:
+        if not points:
+            return {p.id: 0 for p in self.players}
+        max_points = max(points.values()) if points else 0
+        leaders = [pid for pid, value in points.items() if value == max_points]
+        penalties: Dict[str, int] = {}
+        for player in self.players:
+            pid = player.id
+            value = points.get(pid, 0)
+            if pid in leaders:
+                penalties[pid] = 0
+            elif value == 31:
+                penalties[pid] = 2
+            elif value == 0:
+                penalties[pid] = 6
+            else:
+                penalties[pid] = 4
+        return penalties
+
+    def to_state(self, me_id: Optional[str]) -> GameState:
+        self._check_timeout()
+        trick_public = self.current_trick.to_public() if self.current_trick else None
+        discard_cards = list(self.discard_pile) if self.config.discard_visibility == "open" else []
+        hands = self.hands.get(me_id)
+        return GameState(
+            room_id=self.id,
+            room_name=self.name,
+            started=self.started,
+            variant=self.variant,
+            config=self.config,
+            players=self.players,
+            me=next((p for p in self.players if p.id == me_id), None),
+            trump=self.trump,
+            trump_card=self.trump_card,
+            table_cards=[card for play in (trick_public.plays if trick_public else []) for card in play.cards],
+            deck_count=len(self.deck),
+            hands=list(hands) if hands is not None else None,
+            turn_player_id=self.players[self.turn_idx].id if self.players and self.round_active else None,
+            winner_id=self.winner_id,
+            scores=self.scores,
+            trick=trick_public,
+            discard_pile=discard_cards,
+            discard_count=len(self.discard_pile),
+            taken_counts={pid: len(cards) for pid, cards in self.taken_cards.items()},
+            round_points=dict(self.round_summary),
+            announcements=list(self.announcements),
+            turn_deadline_ts=self.turn_deadline,
+            round_number=self.round_number,
+            match_over=self.match_over,
+            winners=list(self.winners),
+            losers=list(self.losers),
+            last_trick_winner_id=self.last_trick_winner_id,
+        )
+
 
 ROOMS: Dict[str, Room] = {}
 
-def list_variants(): return list(VARIANTS.values())
+
+def list_variants() -> List[GameVariant]:
+    return list(VARIANTS.values())
+
 
 def list_rooms_summary():
     res = []
@@ -160,3 +461,35 @@ def list_rooms_summary():
             payload["config"] = r.config.model_dump(by_alias=True)
         res.append(payload)
     return res
+
+
+VARIANTS: Dict[str, GameVariant] = {
+    "classic_3p": GameVariant(
+        key="classic_3p",
+        title="Классика (3 игрока)",
+        players_min=3,
+        players_max=3,
+        description="36 карт, игра до 12 штрафных очков.",
+    ),
+    "classic_2p": GameVariant(
+        key="classic_2p",
+        title="Классика (2 игрока)",
+        players_min=2,
+        players_max=2,
+        description="Дуэльная Бура: добор до 4 карт после каждой взятки.",
+    ),
+    "with_sevens": GameVariant(
+        key="with_sevens",
+        title="С семёрками (3 игрока)",
+        players_min=3,
+        players_max=3,
+        description="Экспериментальные правила с семёрками.",
+    ),
+    "with_draw": GameVariant(
+        key="with_draw",
+        title="Свободный стол (2–4 игрока)",
+        players_min=2,
+        players_max=4,
+        description="Настраиваемый стол с добором до 4 карт.",
+    ),
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -185,19 +185,14 @@ async def ws_room(ws: WebSocket, room_id: str, player_id: str = Query(...)):
             data = await ws.receive_json()
             t = data.get("type")
             if t == "play":
-                ROOMS[room_id].play(data["player_id"], data["card"])
+                cards = data.get("cards")
+                card = data.get("card")
+                if cards is None and card is not None:
+                    cards = [card]
+                ROOMS[room_id].play(data["player_id"], cards or [])
                 await broadcast_room(room_id)
-            elif t == "cover":
-                ROOMS[room_id].cover(data["player_id"], data["card"])
-                await broadcast_room(room_id)
-            elif t == "draw":
-                ROOMS[room_id].draw_up()
-                await broadcast_room(room_id)
-            elif t == "discard":
-                ROOMS[room_id].discard(data.get("player_id"))
-                await broadcast_room(room_id)
-            elif t == "pass":
-                ROOMS[room_id].pass_turn(data.get("player_id"))
+            elif t == "declare":
+                ROOMS[room_id].declare_combination(data["player_id"], data["combo"])
                 await broadcast_room(room_id)
     except WebSocketDisconnect:
         await hub.disconnect(ws)

--- a/backend/models.py
+++ b/backend/models.py
@@ -44,6 +44,25 @@ class Action(BaseModel):
     type: Literal["play","cover","discard","pass"]
     card: Optional[Card] = None
 
+
+class TrickPlay(BaseModel):
+    player_id: str
+    cards: List[Card]
+    outcome: Literal["lead", "beat", "discard"]
+
+
+class TrickState(BaseModel):
+    leader_id: str
+    owner_id: str
+    required_count: int
+    plays: List[TrickPlay] = Field(default_factory=list)
+
+
+class Announcement(BaseModel):
+    player_id: str
+    combo: Literal["bura", "molodka", "moscow", "four_ends"]
+    cards: List[Card]
+
 class GameState(BaseModel):
     room_id: str
     room_name: str
@@ -60,5 +79,17 @@ class GameState(BaseModel):
     turn_player_id: Optional[str] = None
     winner_id: Optional[str] = None
     scores: Dict[str, int] = Field(default_factory=dict)
+    trick: Optional[TrickState] = None
+    discard_pile: List[Card] = Field(default_factory=list)
+    discard_count: int = 0
+    taken_counts: Dict[str, int] = Field(default_factory=dict)
+    round_points: Dict[str, int] = Field(default_factory=dict)
+    announcements: List[Announcement] = Field(default_factory=list)
+    turn_deadline_ts: Optional[float] = None
+    round_number: int = 0
+    match_over: bool = False
+    winners: List[str] = Field(default_factory=list)
+    losers: List[str] = Field(default_factory=list)
+    last_trick_winner_id: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")

--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -1,43 +1,78 @@
 from game import Room, VARIANTS
 from models import Player, Card
 
-def test_turn_enforcement_and_cover_rules():
-    r = Room("r1","T",VARIANTS["classic_2p"])
-    a = Player(id="A", name="A")
-    b = Player(id="B", name="B")
-    r.add_player(a); r.add_player(b)
-    r.start()
-    r.hands[a.id] = [Card(suit=r.trump, rank=10)]
-    r.hands[b.id] = [Card(suit=r.trump, rank=11)]
-    r.table = []
-    r.turn_idx = 0
 
+def make_room(two_players: bool = True) -> Room:
+    variant = VARIANTS["classic_2p"] if two_players else VARIANTS["classic_3p"]
+    room = Room("r", "Test", variant)
+    room.add_player(Player(id="A", name="A"))
+    room.add_player(Player(id="B", name="B"))
+    room.start()
+    # simplify deterministic state
+    room.deck = []
+    room.trump = "♣"
+    room.trump_card = Card(suit="♣", rank=6)
+    room.hands["A"] = []
+    room.hands["B"] = []
+    room.taken_cards = {"A": [], "B": []}
+    room.discard_pile = []
+    room.round_summary = {}
+    room.turn_idx = 0
+    room.round_active = True
+    return room
+
+
+def test_trick_resolution_and_owner_switch():
+    room = make_room()
+    room.hands["A"] = [Card(suit="♠", rank=14), Card(suit="♠", rank=13), Card(suit="♦", rank=6)]
+    room.hands["B"] = [Card(suit="♣", rank=10), Card(suit="♣", rank=9), Card(suit="♦", rank=7)]
+
+    room.play("A", [Card(suit="♠", rank=14), Card(suit="♠", rank=13)])
+    assert room.current_trick is not None
+    assert room.current_trick.owner_id == "A"
+
+    room.play("B", [Card(suit="♣", rank=10), Card(suit="♣", rank=9)])
+    assert room.current_trick is None  # trick finished (2 players)
+    assert room.taken_cards["B"] and len(room.taken_cards["B"]) == 4
+    assert room.last_trick_winner_id == "B"
+    assert room.turn_idx == room._player_index("B")
+
+
+def test_penalties_and_round_summary():
+    room = make_room()
+    room.taken_cards = {
+        "A": [Card(suit="♠", rank=14), Card(suit="♠", rank=10)],
+        "B": [],
+    }
+    room.round_active = True
+    penalties = room._calculate_penalties(room._calculate_round_result())
+    room.round_summary = room._calculate_round_result()
+    room._finalize_round(penalties)
+
+    assert room.scores["A"] == 0
+    assert room.scores["B"] == 6
+    assert room.round_summary["A"] == 21
+    assert room.round_summary["B"] == 0
+
+
+def test_declare_combination():
+    room = make_room()
+    room.hands["A"] = [
+        Card(suit="♣", rank=14),
+        Card(suit="♣", rank=13),
+        Card(suit="♣", rank=12),
+        Card(suit="♣", rank=11),
+    ]
+    room.declared_combos = {"A": set()}
+
+    room.declare_combination("A", "bura")
+    assert len(room.announcements) == 1
+    assert room.announcements[0].combo == "bura"
+    assert all(card.suit == "♣" for card in room.announcements[0].cards)
+
+    # cannot declare twice
     try:
-        r.play("B", r.hands[b.id][0])
-        assert False, "Expected Not your turn"
-    except ValueError as e:
-        assert "Not your turn" in str(e)
-
-    r.play("A", Card(suit=r.trump, rank=10))
-    assert len(r.table) == 1
-    r.cover("B", Card(suit=r.trump, rank=11))
-    assert len(r.table) == 2
-    assert r.current_player_id() == "A"
-
-def test_invalid_cover_rejected():
-    r = Room("r2","T",VARIANTS["classic_2p"])
-    a = Player(id="A", name="A")
-    b = Player(id="B", name="B")
-    r.add_player(a); r.add_player(b)
-    r.start()
-    r.trump = "♠"
-    r.hands[a.id] = [Card(suit="♠", rank=9)]
-    r.hands[b.id] = [Card(suit="♥", rank=14)]
-    r.table = []
-    r.turn_idx = 0
-    r.play("A", Card(suit="♠", rank=9))
-    try:
-        r.cover("B", Card(suit="♥", rank=14))
-        assert False, "Expected Card does not cover"
-    except ValueError as e:
-        assert "Card does not cover" in str(e)
+        room.declare_combination("A", "bura")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -2,32 +2,50 @@ import React from 'react'
 import type { GameState } from '../types'
 import { startGame } from '../api'
 
-export default function Controls({
-  state,
-  onDraw,
-  onPass,
-  onDiscard
-}:{
+type Props = {
   state?: GameState
-  onDraw: ()=>void
-  onPass: ()=>void
-  onDiscard: ()=>void
-}){
+  onDeclare: (combo: string) => void
+}
+
+const COMBOS: { key: 'bura'|'molodka'|'moscow'|'four_ends'; label: string; hint: string }[] = [
+  { key: 'bura', label: 'Бура', hint: '4 козыря' },
+  { key: 'molodka', label: 'Молодка', hint: '4 карты одной масти' },
+  { key: 'moscow', label: 'Москва', hint: '3 туза с козырным' },
+  { key: 'four_ends', label: '4 конца', hint: '4 десятки или 4 туза' },
+]
+
+export default function Controls({ state, onDeclare }: Props){
   const requiredPlayers = state?.config?.maxPlayers ?? state?.variant?.players_min ?? 2
   const canStart = !!state && !state.started && state.players.length >= requiredPlayers
-  const canAct = !!state?.started
+  const canDeclare = !!state?.started && !state?.trick && !state?.match_over
+  const combos = COMBOS.filter(combo => combo.key !== 'four_ends' || state?.config?.enableFourEnds)
+
   return (
     <div className="controls">
       <button
         className="button"
         disabled={!canStart}
         onClick={()=> state?.room_id && startGame(state.room_id)}
+        type="button"
       >
         Старт
       </button>
-      <button className="button secondary" disabled={!canAct} onClick={onPass}>Отбиться</button>
-      <button className="button secondary" disabled={!canAct} onClick={onDiscard}>Сбросить карты</button>
-      <button className="button secondary" onClick={onDraw}>Добор</button>
+
+      <div className="combo-panel">
+        <span className="combo-title">Комбинации:</span>
+        {combos.map(combo => (
+          <button
+            key={combo.key}
+            className="chip"
+            disabled={!canDeclare}
+            onClick={()=> onDeclare(combo.key)}
+            title={combo.hint}
+            type="button"
+          >
+            {combo.label}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,24 +1,18 @@
 import React, { useMemo } from 'react'
-import type { Card, GameState, Player } from '../types'
+import type { GameState, Player, TrickPlay } from '../types'
 import CardView from './CardView'
-
-type TablePair = { attack: Card; defend?: Card }
 
 type Props = {
   state: GameState
   meId?: string
+  turnSecondsLeft?: number
 }
 
-function pairCards(cards: Card[] = []): TablePair[] {
-  const pairs: TablePair[] = []
-  for (let i = 0; i < cards.length; i += 2) {
-    const attack = cards[i]
-    const defend = cards[i + 1]
-    if (attack) {
-      pairs.push({ attack, defend })
-    }
-  }
-  return pairs
+const COMBO_LABELS: Record<string, string> = {
+  bura: 'Бура',
+  molodka: 'Молодка',
+  moscow: 'Москва',
+  four_ends: '4 конца',
 }
 
 function sortPlayers(players: Player[], meId?: string): Player[] {
@@ -30,108 +24,133 @@ function sortPlayers(players: Player[], meId?: string): Player[] {
   return ordered.slice(myIndex).concat(ordered.slice(0, myIndex))
 }
 
-function OpponentBadge({ player, isTurn, score }: {
-  player: Player
-  isTurn: boolean
-  score?: number
-}) {
-  return (
-    <div className={`opponent-badge ${isTurn ? 'turn' : ''}`}>
-      <div className="opponent-name">{player.name}</div>
-      <div className="opponent-meta">
-        <span className="pill">Счёт: {score ?? 0}</span>
-      </div>
-    </div>
-  )
+function describeOutcome(play: TrickPlay, ownerId?: string): string {
+  if (play.outcome === 'lead') return 'Ход'
+  if (play.outcome === 'beat') return ownerId === play.player_id ? 'Перебил' : 'Перебил'
+  return 'Сброс'
 }
 
-export default function TableView({ state, meId }: Props) {
-  const pairs = useMemo(() => pairCards(state.table_cards), [state.table_cards])
+export default function TableView({ state, meId, turnSecondsLeft }: Props) {
   const orderedPlayers = useMemo(() => sortPlayers(state.players, meId), [state.players, meId])
-  const me = orderedPlayers[0]?.id === meId ? orderedPlayers[0] : undefined
-  const opponents = me ? orderedPlayers.slice(1) : orderedPlayers
-  const top = opponents[0]
-  const right = opponents[1]
-  const left = opponents[2]
+  const scores = state.scores || {}
+  const trickPlays = state.trick?.plays ?? []
+  const discardCards = state.discard_pile ?? []
+  const takenCounts = state.taken_counts ?? {}
+  const announcements = state.announcements ?? []
+  const winners = state.match_over ? state.winners ?? [] : []
+  const losers = state.match_over ? state.losers ?? [] : []
 
   const suitToEmoji: Record<string, string> = { S:'♠️', H:'♥️', D:'♦️', C:'♣️', s:'♠️', h:'♥️', d:'♦️', c:'♣️' }
   const trumpEmoji = state.trump ? (suitToEmoji[state.trump] ?? state.trump) : ''
-  const scores = state.scores || {}
+
+  const isMyTurn = state.turn_player_id && state.turn_player_id === meId
 
   return (
     <div className="table-layout">
       <div className="score-row">
         {orderedPlayers.map(player => (
-          <div
-            key={player.id}
-            className={`score-chip ${state.turn_player_id === player.id ? 'active' : ''}`}
-          >
+          <div key={player.id} className={`score-chip ${state.turn_player_id === player.id ? 'active' : ''}`}>
             <span className="score-name">{player.name}</span>
-            <span className="score-value">{scores[player.id] ?? 0}</span>
+            <span className="score-value">Штраф: {scores[player.id] ?? 0}</span>
+            <span className="score-sub">Взято карт: {takenCounts[player.id] ?? 0}</span>
           </div>
         ))}
       </div>
 
-      <div className="board-grid">
-        <div className="seat seat-top">
-          {top && (
-            <OpponentBadge
-              player={top}
-              isTurn={state.turn_player_id === top.id}
-              score={scores[top.id]}
-            />
-          )}
-        </div>
-        <div className="seat seat-left">
-          {left && (
-            <OpponentBadge
-              player={left}
-              isTurn={state.turn_player_id === left.id}
-              score={scores[left.id]}
-            />
-          )}
-        </div>
+      <div className="table-status">
+        <div className="status-pill">Раунд {state.round_number ?? 1}</div>
+        <div className="status-pill">Колода: {state.deck_count}</div>
+        <div className="status-pill">Козырь {trumpEmoji}</div>
+        {typeof turnSecondsLeft === 'number' && (
+          <div className={`status-pill timer ${isMyTurn ? 'active' : ''}`}>
+            Ход {turnSecondsLeft} с
+          </div>
+        )}
+      </div>
 
-        <div className="table-center">
-          <div className="table-pairs">
-            {pairs.length === 0 && <div className="table-placeholder">Ходите картой</div>}
-            {pairs.map((pair, idx) => (
-              <div className="table-pair" key={`${pair.attack.suit}${pair.attack.rank}-${idx}`}>
-                <div className="table-card attack">
-                  <CardView card={pair.attack} />
-                </div>
-                <div className={`table-card defend ${pair.defend ? 'visible' : 'ghost'}`}>
-                  {pair.defend ? <CardView card={pair.defend} /> : null}
-                </div>
+      {state.match_over && (
+        <div className="panel match-result">
+          <div className="panel-title">Матч завершён</div>
+          <div className="panel-body">
+            {winners.length > 0 && (
+              <div className="result-line">
+                <strong>Победители:</strong>
+                <span>{winners.map(id => state.players.find(p => p.id === id)?.name ?? id).join(', ')}</span>
               </div>
+            )}
+            {losers.length > 0 && (
+              <div className="result-line">
+                <strong>Проигравшие:</strong>
+                <span>{losers.map(id => state.players.find(p => p.id === id)?.name ?? id).join(', ')}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="plays-board">
+        <div className="plays-header">
+          <div className="plays-title">Текущая взятка</div>
+          {state.trick?.required_count && (
+            <div className="pill">по {state.trick.required_count} карт(ы)</div>
+          )}
+        </div>
+        {trickPlays.length === 0 && <div className="plays-placeholder">Нет карт на столе</div>}
+        {trickPlays.map((play, idx) => {
+          const player = state.players.find(p => p.id === play.player_id)
+          return (
+            <div key={`${play.player_id}-${idx}`} className={`play-row ${play.player_id === state.trick?.owner_id ? 'owner' : ''}`}>
+              <div className="play-player">{player?.name || play.player_id}</div>
+              <div className="play-cards">
+                {play.cards.map((card, i) => (
+                  <CardView key={`${card.suit}${card.rank}-${i}`} card={card} />
+                ))}
+              </div>
+              <div className={`play-outcome outcome-${play.outcome}`}>{describeOutcome(play, state.trick?.owner_id)}</div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="info-panels">
+        <div className="panel">
+          <div className="panel-title">Сброс ({state.discard_count ?? discardCards.length})</div>
+          <div className="panel-body discard-cards">
+            {discardCards.length === 0 && <span className="muted">Пока пусто</span>}
+            {discardCards.slice(-6).map((card, idx) => (
+              <CardView key={`${card.suit}${card.rank}-d${idx}`} card={card} />
             ))}
           </div>
-          <div className="trump-info">
-            <div className="trump-label">Козырь {trumpEmoji}</div>
-            <div className={`trump-card ${state.trump_card ? '' : 'ghost'}`}>
-              {state.trump_card ? <CardView card={state.trump_card} /> : <span>—</span>}
-            </div>
-            <div className="deck-counter">Колода: {state.deck_count}</div>
-          </div>
         </div>
 
-        <div className="seat seat-right">
-          {right && (
-            <OpponentBadge
-              player={right}
-              isTurn={state.turn_player_id === right.id}
-              score={scores[right.id]}
-            />
-          )}
+        <div className="panel">
+          <div className="panel-title">Комбинации</div>
+          <div className="panel-body combos">
+            {announcements.length === 0 && <span className="muted">Не объявлялись</span>}
+            {announcements.map((entry, idx) => {
+              const player = state.players.find(p => p.id === entry.player_id)
+              const label = COMBO_LABELS[entry.combo] ?? entry.combo
+              return (
+                <div key={`${entry.player_id}-${entry.combo}-${idx}`} className="combo-entry">
+                  <span className="combo-player">{player?.name || entry.player_id}</span>
+                  <span className="combo-name">{label}</span>
+                </div>
+              )
+            })}
+          </div>
         </div>
       </div>
 
-      {me && (
-        <div className="player-badge">
-          <div className="player-name">{me.name}</div>
-          <div className="player-meta">
-            <span className="pill">Вы</span>
-            <span className="pill">Счёт: {scores[me.id] ?? 0}</span>
+      {state.round_points && Object.keys(state.round_points).length > 0 && (
+        <div className="panel round-summary">
+          <div className="panel-title">Очки последнего раунда</div>
+          <div className="panel-body round-points">
+            {orderedPlayers.map(player => (
+              <div key={`pts-${player.id}`} className="round-point-row">
+                <span>{player.name}</span>
+                <span>{state.round_points?.[player.id] ?? 0}</span>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -59,7 +59,9 @@ body { margin: 0; }
 .room-meta{display:flex;gap:8;align-items:center;justify-content:flex-end}
 .room-actions{display:flex;gap:8}
 .badge.warn{background:#fff7e6;border:1px solid #fde1a8}
-.controls{display:flex;gap:8}
+.controls{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.combo-panel{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.combo-title{font-size:12px;color:var(--muted);font-weight:600}
 .input{flex:1 1 auto;padding:10px 12px;border:1px solid #ddd;border-radius:10px}
 
 /* ======= THEME (light/dark) ======= */
@@ -205,12 +207,22 @@ body, .app{
 }
 
 /* ===== Hand ===== */
-.hand{ display:flex; gap:8px; flex-wrap: wrap; }
-.hand.deal-anim .hand-card{
-  animation: deal .35s ease both;
+.hand{ display:grid; gap:12px; padding:12px; border:1px solid var(--border); border-radius:16px; background:var(--card); }
+.hand.deal-anim .hand-card{ animation: deal .35s ease both; }
+.hand-hint{ font-size:12px; color:var(--muted); }
+.hand-cards{ display:flex; flex-wrap:wrap; gap:8px; }
+.hand-card{ border:none; background:none; padding:0; cursor:pointer; position:relative; }
+.hand-card.selected::after{
+  content:'';
+  position:absolute; inset:-4px;
+  border-radius:12px;
+  border:2px solid var(--primary);
+  box-shadow:0 0 0 3px color-mix(in srgb, var(--primary) 25%, transparent);
 }
-.hand-card{ cursor: pointer; }
-.hand-card:active .card{ transform: translateY(-2px) scale(1.02); box-shadow: 0 6px 16px rgba(0,0,0,.15); }
+.hand-card:disabled{ opacity:.5; cursor:not-allowed; }
+.hand-actions{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.chip{ padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); cursor:pointer; font-size:12px; }
+.chip:disabled{ opacity:.5; cursor:not-allowed; }
 
 @keyframes deal{
   from{ transform: translateY(8px); opacity: .0; }
@@ -227,44 +239,47 @@ body, .app{
 .pill{ display:inline-flex; align-items:center; gap:4px; padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.06); color:var(--muted); font-size:12px; }
 html[data-theme="dark"] .pill{ background:rgba(255,255,255,.08); color:var(--fg); }
 
+
 .table-layout{ display:grid; gap:16px; padding:12px; border:1px solid var(--border); border-radius:20px; background:var(--card); box-shadow:0 12px 28px rgba(0,0,0,.12); }
 .score-row{ display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
-.score-chip{ padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.05); color:var(--muted); font-size:12px; display:flex; gap:6px; align-items:center; transition:all .2s ease; }
+.score-chip{ padding:8px 12px; border-radius:16px; background:rgba(0,0,0,.05); color:var(--muted); font-size:12px; display:grid; gap:4px; transition:all .2s ease; min-width:140px; }
 .score-chip.active{ background:var(--primary); color:var(--primary-fg); }
-.score-name{ font-weight:600; }
-.score-value{ font-weight:700; }
+.score-name{ font-weight:700; font-size:13px; }
+.score-value{ font-weight:600; }
+.score-sub{ font-size:11px; opacity:.8; }
 
-.board-grid{ display:grid; grid-template-columns:120px 1fr 120px; grid-template-rows:auto auto; gap:12px; align-items:center; }
-.seat{ display:flex; justify-content:center; align-items:center; min-height:80px; }
-.seat-top{ grid-column:1 / span 3; justify-content:center; }
-.seat-left{ grid-column:1 / span 1; grid-row:2; justify-content:flex-start; }
-.seat-right{ grid-column:3 / span 1; grid-row:2; justify-content:flex-end; }
-.table-center{ grid-column:2; grid-row:2; display:flex; align-items:center; justify-content:center; gap:24px; position:relative; }
+.table-status{ display:flex; flex-wrap:wrap; gap:8px; }
+.status-pill{ padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.05); font-size:12px; color:var(--muted); }
+.status-pill.timer{ font-weight:700; }
+.status-pill.timer.active{ background:var(--primary); color:var(--primary-fg); }
 
-.table-pairs{ display:flex; flex-wrap:wrap; gap:18px; min-height:130px; }
-.table-pair{ position:relative; width:110px; height:120px; }
-.table-card{ position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); transition:transform .3s ease, opacity .3s ease; }
-.table-card.attack{ transform:translate(-50%, -50%) rotate(-4deg); animation:drop-attack .3s ease; }
-.table-card.defend{ opacity:0; transform:translate(-50%, -50%) rotate(10deg); }
-.table-card.defend.visible{ opacity:1; animation:cover-card .3s ease forwards; }
-.table-card.defend.ghost{ opacity:.2; border:1px dashed var(--border); border-radius:10px; width:68px; height:96px; display:grid; place-items:center; }
-.table-card > .card{ box-shadow:0 8px 16px rgba(0,0,0,.15); }
+.plays-board{ display:grid; gap:10px; border:1px dashed var(--border); border-radius:16px; padding:12px; background:color-mix(in srgb, var(--card) 80%, transparent); }
+.plays-header{ display:flex; gap:8px; align-items:center; justify-content:space-between; }
+.plays-title{ font-weight:700; }
+.plays-placeholder{ font-size:12px; color:var(--muted); }
+.play-row{ display:grid; grid-template-columns: 120px 1fr auto; gap:8px; align-items:center; padding:6px 8px; border-radius:10px; background:rgba(0,0,0,.04); }
+.play-row.owner{ border:1px solid var(--primary); box-shadow:0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent); }
+.play-player{ font-weight:600; font-size:13px; }
+.play-cards{ display:flex; gap:6px; flex-wrap:wrap; }
+.play-outcome{ font-size:12px; font-weight:600; }
+.play-outcome.outcome-discard{ color:#d9534f; }
 
-.table-placeholder{ padding:16px 20px; border-radius:12px; border:1px dashed var(--border); color:var(--muted); font-size:12px; }
+.info-panels{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.panel{ border:1px solid var(--border); border-radius:16px; padding:12px; background:var(--card); display:grid; gap:8px; }
+.panel-title{ font-weight:700; font-size:13px; }
+.panel-body{ display:flex; flex-wrap:wrap; gap:6px; font-size:12px; }
+.discard-cards .card{ width:48px; height:72px; }
+.muted{ color:var(--muted); }
+.combos{ flex-direction:column; align-items:flex-start; }
+.combo-entry{ display:flex; gap:6px; font-size:12px; background:rgba(0,0,0,.05); padding:4px 8px; border-radius:10px; }
+.combo-player{ font-weight:600; }
+.combo-name{ font-weight:700; }
 
-.trump-info{ display:grid; gap:6px; text-align:center; }
-.trump-label{ font-size:12px; font-weight:700; }
-.trump-card{ width:68px; height:96px; display:grid; place-items:center; border-radius:12px; border:1px solid var(--border); background:var(--bg); box-shadow:0 4px 14px rgba(0,0,0,.15); }
-.trump-card.ghost{ color:var(--muted); }
-.deck-counter{ font-size:12px; color:var(--muted); }
-
-.opponent-badge{ display:grid; gap:4px; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:rgba(0,0,0,.04); min-width:120px; text-align:center; transition:transform .2s ease; }
-.opponent-badge.turn{ transform:translateY(-4px); border-color:var(--primary); box-shadow:0 0 0 3px color-mix(in srgb, var(--primary) 20%, transparent); }
-.opponent-name{ font-weight:700; }
-.opponent-meta{ display:flex; flex-direction:column; gap:4px; font-size:11px; color:var(--muted); }
-
-.player-badge{ justify-self:center; display:flex; gap:8px; align-items:center; padding:10px 16px; border-radius:999px; border:1px solid var(--border); background:var(--card); font-weight:700; }
-.player-meta{ display:flex; gap:6px; }
+.round-summary{ margin-top:-4px; }
+.round-points{ display:grid; gap:6px; }
+.round-point-row{ display:flex; justify-content:space-between; font-size:13px; }
+.match-result .panel-body{ flex-direction:column; align-items:flex-start; gap:6px; }
+.result-line{ display:flex; gap:6px; font-size:13px; }
 
 .hand-wrap{ display:grid; gap:8px; }
 .hand-title{ margin:0; font-size:14px; font-weight:700; }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,9 @@
 export type Suit = '♠'|'♥'|'♦'|'♣'
 export type Card = { suit: Suit; rank: number }
+export type TrickPlayOutcome = 'lead'|'beat'|'discard'
+export type TrickPlay = { player_id: string; cards: Card[]; outcome: TrickPlayOutcome }
+export type TrickState = { leader_id: string; owner_id: string; required_count: number; plays: TrickPlay[] }
+export type Announcement = { player_id: string; combo: 'bura'|'molodka'|'moscow'|'four_ends'; cards: Card[] }
 export type DiscardVisibility = 'open'|'faceDown'
 export type TableConfig = {
   maxPlayers: 2|3|4
@@ -25,4 +29,16 @@ export type GameState = {
   turn_player_id?: string
   winner_id?: string
   scores?: Record<string, number>
+  trick?: TrickState
+  discard_pile?: Card[]
+  discard_count?: number
+  taken_counts?: Record<string, number>
+  round_points?: Record<string, number>
+  announcements?: Announcement[]
+  turn_deadline_ts?: number
+  round_number?: number
+  match_over?: boolean
+  winners?: string[]
+  losers?: string[]
+  last_trick_winner_id?: string
 }


### PR DESCRIPTION
## Summary
- replace the room engine with a full implementation of the Bura ruleset, including scoring, trick resolution, combinations and turn timers
- expose richer state in the API/WebSocket payloads and add a declare-combination action
- refresh the in-room UI with multi-card selection, trick summaries, discard/combo panels and a visible turn countdown
- extend the rules test suite to cover the new flow and combination declarations

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b232b15c8332a36a5a1c3614008c