### PR TITLE
Implement trick grid UI and card play validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -184,12 +184,17 @@ async def ws_room(ws: WebSocket, room_id: str, player_id: str = Query(...)):
         while True:
             data = await ws.receive_json()
             t = data.get("type")
-            if t == "play":
+            if t in {"play", "play_cards"}:
                 cards = data.get("cards")
                 card = data.get("card")
                 if cards is None and card is not None:
                     cards = [card]
-                ROOMS[room_id].play(data["player_id"], cards or [])
+                kwargs = {}
+                if "roundId" in data:
+                    kwargs["round_id"] = data["roundId"]
+                if "trickIndex" in data:
+                    kwargs["trick_index"] = data["trickIndex"]
+                ROOMS[room_id].play_cards(data["player_id"], cards or [], **kwargs)
                 await broadcast_room(room_id)
             elif t == "declare":
                 ROOMS[room_id].declare_combination(data["player_id"], data["combo"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,16 @@ class Card(BaseModel):
     suit: Suit
     rank: int  # 6..14 (11=J,12=Q,13=K,14=A)
 
+
+class PublicCard(BaseModel):
+    suit: Optional[Suit] = None
+    rank: Optional[int] = None
+    hidden: bool = False
+
+    @classmethod
+    def hidden_card(cls) -> "PublicCard":
+        return cls(hidden=True)
+
 class Player(BaseModel):
     id: str
     name: str
@@ -47,14 +57,19 @@ class Action(BaseModel):
 
 class TrickPlay(BaseModel):
     player_id: str
-    cards: List[Card]
-    outcome: Literal["lead", "beat", "discard"]
+    seat: int
+    cards: List[PublicCard]
+    outcome: Literal["lead", "beat", "partial", "discard"]
+    owner: bool = False
 
 
 class TrickState(BaseModel):
     leader_id: str
+    leader_seat: int
     owner_id: str
+    owner_seat: int
     required_count: int
+    trick_index: int
     plays: List[TrickPlay] = Field(default_factory=list)
 
 
@@ -73,9 +88,10 @@ class GameState(BaseModel):
     me: Optional[Player]
     trump: Optional[Suit]
     trump_card: Optional[Card]
-    table_cards: List[Card]
+    table_cards: List[PublicCard]
     deck_count: int
     hands: Optional[List[Card]] = None
+    hand_counts: Dict[str, int] = Field(default_factory=dict)
     turn_player_id: Optional[str] = None
     winner_id: Optional[str] = None
     scores: Dict[str, int] = Field(default_factory=dict)
@@ -87,6 +103,7 @@ class GameState(BaseModel):
     announcements: List[Announcement] = Field(default_factory=list)
     turn_deadline_ts: Optional[float] = None
     round_number: int = 0
+    round_id: Optional[str] = None
     match_over: bool = False
     winners: List[str] = Field(default_factory=list)
     losers: List[str] = Field(default_factory=list)

--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -27,16 +27,30 @@ def test_trick_resolution_and_owner_switch():
     room.hands["A"] = [Card(suit="♠", rank=14), Card(suit="♠", rank=13), Card(suit="♦", rank=6)]
     room.hands["B"] = [Card(suit="♣", rank=10), Card(suit="♣", rank=9), Card(suit="♦", rank=7)]
 
-    room.play("A", [Card(suit="♠", rank=14), Card(suit="♠", rank=13)])
+    room.play_cards("A", [Card(suit="♠", rank=14), Card(suit="♠", rank=13)])
     assert room.current_trick is not None
     assert room.current_trick.owner_id == "A"
 
-    room.play("B", [Card(suit="♣", rank=10), Card(suit="♣", rank=9)])
+    room.play_cards("B", [Card(suit="♣", rank=10), Card(suit="♣", rank=9)])
     assert room.current_trick is None  # trick finished (2 players)
     assert room.taken_cards["B"] and len(room.taken_cards["B"]) == 4
     assert room.last_trick_winner_id == "B"
     assert room.turn_idx == room._player_index("B")
 
+
+def test_partial_response_keeps_owner():
+    room = make_room()
+    room.hands["A"] = [Card(suit="♠", rank=12), Card(suit="♠", rank=11), Card(suit="♥", rank=6)]
+    room.hands["B"] = [Card(suit="♣", rank=10), Card(suit="♠", rank=6), Card(suit="♦", rank=7)]
+
+    room.play_cards("A", [Card(suit="♠", rank=12), Card(suit="♠", rank=11)])
+    assert room.current_trick is not None
+    assert room.current_trick.owner_id == "A"
+
+    room.play_cards("B", [Card(suit="♣", rank=10), Card(suit="♠", rank=6)])
+    assert room.current_trick is None
+    assert room.last_trick_winner_id == "A"
+    assert room.taken_cards["A"] and len(room.taken_cards["A"]) == 4
 
 def test_penalties_and_round_summary():
     room = make_room()

--- a/frontend/src/components/CardView.tsx
+++ b/frontend/src/components/CardView.tsx
@@ -1,19 +1,28 @@
 import React from 'react'
-import type { Card } from '../types'
+import type { Card, PublicCard } from '../types'
 
 const suitToEmoji: Record<string, string> = {
   S: '♠️', H: '♥️', D: '♦️', C: '♣️',
   s: '♠️', h: '♥️', d: '♦️', c: '♣️'
 }
 
-export default function CardView({ card }: { card: Card }) {
+type Props = { card: PublicCard; muted?: boolean }
+
+export default function CardView({ card, muted }: Props) {
+  if ('hidden' in card && card.hidden) {
+    return (
+      <div className={`card hidden ${muted ? 'muted' : ''}`} aria-label="Не видно">
+        <div className="card-rank">XX</div>
+      </div>
+    )
+  }
   const suit = suitToEmoji[card.suit] ?? card.suit
   const rankMap: Record<number, string> = { 11: 'В', 12: 'Д', 13: 'К', 14: 'Т' }
   const rank = rankMap[card.rank] ?? card.rank
   const isRed = card.suit === '♥' || card.suit === '♦'
   const label = `${rank}${suit}`
   return (
-    <div className={`card ${isRed ? 'red' : ''}`} title={label} aria-label={label}>
+    <div className={`card ${isRed ? 'red' : ''} ${muted ? 'muted' : ''}`} title={label} aria-label={label}>
       <div className="card-rank">{rank}</div>
       <div className="card-suit">{suit}</div>
     </div>

--- a/frontend/src/components/Hand.tsx
+++ b/frontend/src/components/Hand.tsx
@@ -1,96 +1,394 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import type { Card } from '../types'
+import type { Card, TrickState, Suit } from '../types'
 import CardView from './CardView'
+
+type DragPreview = { cards: Card[]; valid: boolean }
 
 type Props = {
   cards: Card[]
-  requiredCount?: number
+  trick?: TrickState
+  trump?: Suit
   isMyTurn?: boolean
-  onPlay: (cards: Card[]) => void
+  playStamp?: number
+  onPlay: (cards: Card[], meta?: { viaDrop?: boolean }) => void
+  onDragPreview?: (preview: DragPreview | null) => void
+  meId?: string
 }
 
-function cardKey(card: Card): string {
-  return `${card.suit}-${card.rank}`
+const RANK_ORDER = [6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+function rankStrength(rank: number): number {
+  return RANK_ORDER.indexOf(rank)
 }
 
-export default function Hand({ cards, requiredCount, isMyTurn, onPlay }: Props) {
+function canBeatCard(card: Card, other: Card, trump?: Suit): boolean {
+  if (card.suit === other.suit) {
+    return rankStrength(card.rank) > rankStrength(other.rank)
+  }
+  if (card.suit === trump && other.suit !== trump) {
+    return true
+  }
+  return false
+}
+
+function maxBeatCount(challenger: Card[], owner: Card[], trump?: Suit): number {
+  const used = new Array(challenger.length).fill(false)
+
+  function helper(ownerIndex: number): number {
+    if (ownerIndex >= owner.length) return 0
+    const skip = helper(ownerIndex + 1)
+    let best = skip
+    for (let i = 0; i < challenger.length; i += 1) {
+      if (used[i]) continue
+      if (!canBeatCard(challenger[i], owner[ownerIndex], trump)) continue
+      used[i] = true
+      best = Math.max(best, 1 + helper(ownerIndex + 1))
+      used[i] = false
+    }
+    return best
+  }
+
+  return helper(0)
+}
+
+function combinations(total: number, size: number): number[][] {
+  const result: number[][] = []
+  const indexes = Array.from({ length: total }, (_, i) => i)
+
+  function backtrack(start: number, combo: number[]) {
+    if (combo.length === size) {
+      result.push([...combo])
+      return
+    }
+    for (let i = start; i < indexes.length; i += 1) {
+      combo.push(indexes[i])
+      backtrack(i + 1, combo)
+      combo.pop()
+    }
+  }
+
+  backtrack(0, [])
+  return result
+}
+
+function scoreCombination(indexes: number[], cards: Card[], trump?: Suit): number {
+  return indexes.reduce((sum, idx) => sum + (cards[idx].suit === trump ? 100 : 0) + rankStrength(cards[idx].rank), 0)
+}
+
+function suggestResponseIndexes(cards: Card[], owner: Card[], required: number, trump?: Suit): number[] | null {
+  if (!required) return null
+  const combos = combinations(cards.length, required)
+  if (combos.length === 0) return null
+
+  const winning: number[][] = []
+  const fallback: number[][] = []
+
+  combos.forEach(combo => {
+    const sample = combo.map(idx => cards[idx])
+    const beatCount = maxBeatCount(sample, owner, trump)
+    if (beatCount === owner.length && owner.length === required) {
+      winning.push(combo)
+    } else {
+      fallback.push(combo)
+    }
+  })
+
+  if (winning.length > 0) {
+    winning.sort((a, b) => scoreCombination(a, cards, trump) - scoreCombination(b, cards, trump))
+    return winning[0]
+  }
+
+  fallback.sort((a, b) => {
+    const trumpCountA = a.filter(idx => cards[idx].suit === trump).length
+    const trumpCountB = b.filter(idx => cards[idx].suit === trump).length
+    if (trumpCountA !== trumpCountB) return trumpCountA - trumpCountB
+    return scoreCombination(a, cards, trump) - scoreCombination(b, cards, trump)
+  })
+  return fallback[0] ?? null
+}
+
+function suggestLeaderFromIndex(cards: Card[], index: number): number[] {
+  const targetSuit = cards[index].suit
+  const sameSuit = cards
+    .map((card, idx) => ({ card, idx }))
+    .filter(({ card }) => card.suit === targetSuit)
+    .sort((a, b) => rankStrength(b.card.rank) - rankStrength(a.card.rank))
+  const picks: number[] = [index]
+  for (const entry of sameSuit) {
+    if (picks.length >= 3) break
+    if (entry.idx === index) continue
+    picks.push(entry.idx)
+  }
+  return picks.sort((a, b) => a - b)
+}
+
+function suggestLeaderBest(cards: Card[]): number[] | null {
+  const grouped = new Map<Suit, { idx: number; value: number }[]>()
+  cards.forEach((card, idx) => {
+    if (!grouped.has(card.suit)) grouped.set(card.suit, [])
+    grouped.get(card.suit)!.push({ idx, value: rankStrength(card.rank) })
+  })
+  let best: number[] | null = null
+  grouped.forEach(entries => {
+    const ordered = entries.sort((a, b) => b.value - a.value)
+    const picks = ordered.slice(0, Math.min(3, ordered.length)).map(entry => entry.idx)
+    if (!best || picks.length > best.length || (picks.length === best.length && scoreCombination(picks, cards) < scoreCombination(best, cards))) {
+      best = picks
+    }
+  })
+  return best ? [...best].sort((a, b) => a - b) : null
+}
+
+function isVisibleCard(card: { hidden?: boolean }): card is Card {
+  return !("hidden" in card && card.hidden)
+}
+
+export default function Hand({ cards, trick, trump, isMyTurn, playStamp, onPlay, onDragPreview, meId }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([])
+  const pointerRef = useRef<{ index: number; y: number } | null>(null)
   const [selected, setSelected] = useState<number[]>([])
+  const [dragging, setDragging] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [focusIndex, setFocusIndex] = useState(0)
 
-  useEffect(()=>{
+  const leaderMode = !trick || trick.plays.length === 0
+  const requiredCount = leaderMode ? undefined : trick?.required_count
+  const ownerCards = useMemo(() => {
+    if (!trick) return [] as Card[]
+    const ownerPlay = trick.plays.find(play => play.owner)
+    if (!ownerPlay) return [] as Card[]
+    return ownerPlay.cards.filter(isVisibleCard)
+  }, [trick])
+
+  useEffect(() => {
     const el = containerRef.current
     if (!el) return
     el.classList.remove('deal-anim')
-    const id = setTimeout(()=> el.classList.add('deal-anim'), 0)
-    return ()=> clearTimeout(id)
-  }, [cards.map(cardKey).join(',')])
+    const id = window.setTimeout(() => el.classList.add('deal-anim'), 0)
+    return () => window.clearTimeout(id)
+  }, [cards.map(card => `${card.suit}${card.rank}`).join(',')])
 
-  useEffect(()=>{
-    setSelected(prev => prev.filter(index => index < cards.length))
+  useEffect(() => {
+    setSelected(prev => prev.filter(idx => idx < cards.length))
   }, [cards.length])
 
-  const selectionSuit = useMemo(()=>{
-    if (requiredCount) return null
-    if (selected.length === 0) return null
-    return cards[selected[0]]?.suit ?? null
-  }, [selected, cards, requiredCount])
+  useEffect(() => {
+    setSelected([])
+    setDragging(false)
+    setError(null)
+  }, [playStamp])
+
+  useEffect(() => {
+    return () => {
+      onDragPreview?.(null)
+    }
+  }, [onDragPreview])
+
+  useEffect(() => {
+    setError(null)
+  }, [selected.join(','), isMyTurn, requiredCount])
 
   const selectedCards = selected.map(idx => cards[idx]).filter(Boolean)
-  const maxSelectable = requiredCount ?? 3
+  const ownerLabel = trick ? (trick.owner_id === meId ? 'Ты' : trick.owner_id?.slice(0, 4) ?? '—') : '—'
 
-  const isSelectionValid = useMemo(()=>{
-    if (!isMyTurn) return false
-    if (requiredCount) return selectedCards.length === requiredCount
-    if (selectedCards.length === 0 || selectedCards.length > 3) return false
-    const suits = new Set(selectedCards.map(c => c.suit))
-    return suits.size === 1
-  }, [isMyTurn, requiredCount, selectedCards])
-
-  function toggle(index: number){
-    const already = selected.includes(index)
-    if (already){
-      setSelected(prev => prev.filter(i => i !== index))
-      return
+  function evaluateSelection(indices: number[]): { countValid: boolean; message: string } {
+    const picks = indices.map(idx => cards[idx]).filter(Boolean)
+    if (picks.length === 0) {
+      return {
+        countValid: false,
+        message: leaderMode ? 'Выберите до трёх карт одной масти' : `Нужно положить ровно ${requiredCount} карт`,
+      }
     }
-    if (requiredCount){
-      if (selected.length >= requiredCount) return
-      setSelected(prev => [...prev, index])
-      return
+    if (picks.length > 3) {
+      return { countValid: false, message: 'Нельзя выбрать больше трёх карт' }
     }
-    if (selected.length >= maxSelectable){
-      setSelected([index])
-      return
+    if (leaderMode) {
+      const suits = new Set(picks.map(card => card.suit))
+      if (suits.size > 1) {
+        return { countValid: false, message: 'Для лидера все карты должны быть одной масти' }
+      }
+      return { countValid: true, message: `Вы кладёте ${picks.length} карт` }
     }
-    if (selectionSuit && cards[index]?.suit !== selectionSuit){
-      setSelected([index])
-      return
+    if (requiredCount && picks.length !== requiredCount) {
+      return { countValid: false, message: `Нужно положить ровно ${requiredCount} карт` }
     }
-    setSelected(prev => [...prev, index])
+    return { countValid: true, message: `Готово: ${picks.length} карта(ы)` }
   }
 
-  function handlePlay(){
-    if (!isSelectionValid) return
-    onPlay(selectedCards)
+  const validation = useMemo(() => evaluateSelection(selected), [selected, leaderMode, requiredCount])
+  const canSubmit = Boolean(isMyTurn && validation.countValid)
+  const helperText = useMemo(() => {
+    if (!isMyTurn) return 'Ждём хода соперника'
+    if (error) return error
+    return validation.message
+  }, [isMyTurn, validation.message, error])
+
+  function toggle(index: number) {
+    setSelected(prev => {
+      if (prev.includes(index)) {
+        return prev.filter(i => i !== index)
+      }
+      if (!leaderMode && requiredCount && prev.length >= requiredCount) {
+        return [index]
+      }
+      if (leaderMode && prev.length >= 3) {
+        return [index]
+      }
+      return [...prev, index].sort((a, b) => a - b)
+    })
+    setFocusIndex(index)
+  }
+
+  function handlePlay(meta?: { viaDrop?: boolean }) {
+    if (!canSubmit) {
+      setError(isMyTurn ? validation.message : 'Сейчас ход другого игрока')
+      return
+    }
+    if (selectedCards.length === 0) return
+    onDragPreview?.(null)
+    onPlay([...selectedCards], meta)
+  }
+
+  function handleClear() {
     setSelected([])
+    setError(null)
+    onDragPreview?.(null)
   }
+
+  function applyHint(baseIndex?: number) {
+    let suggestion: number[] | null = null
+    if (leaderMode) {
+      if (baseIndex !== undefined) {
+        suggestion = suggestLeaderFromIndex(cards, baseIndex)
+      } else {
+        suggestion = suggestLeaderBest(cards)
+      }
+    } else if (requiredCount) {
+      suggestion = suggestResponseIndexes(cards, ownerCards, requiredCount, trump)
+    }
+    if (suggestion && suggestion.length) {
+      setSelected([...suggestion].sort((a, b) => a - b))
+      setError(null)
+      setFocusIndex(suggestion[0])
+    }
+  }
+
+  function handleDoubleClick(index: number) {
+    if (leaderMode) {
+      applyHint(index)
+    } else {
+      applyHint()
+    }
+  }
+
+  function handleDragStart(index: number, event: React.DragEvent<HTMLButtonElement>) {
+    if (!isMyTurn) {
+      event.preventDefault()
+      return
+    }
+    const already = selected.includes(index)
+    const future = already ? selected : [index]
+    if (!already) {
+      setSelected(future)
+    }
+    const previewValidation = evaluateSelection(future)
+    const previewCards = future.map(idx => cards[idx])
+    setDragging(true)
+    onDragPreview?.({ cards: previewCards, valid: previewValidation.countValid && Boolean(isMyTurn) })
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('application/x-bura-cards', JSON.stringify({ count: future.length }))
+  }
+
+  function handleDragEnd() {
+    setDragging(false)
+    onDragPreview?.(null)
+  }
+
+  function handlePointerDown(index: number, event: React.PointerEvent<HTMLButtonElement>) {
+    if (event.pointerType === 'touch') {
+      pointerRef.current = { index, y: event.clientY }
+    }
+  }
+
+  function handlePointerUp(index: number, event: React.PointerEvent<HTMLButtonElement>) {
+    if (pointerRef.current && pointerRef.current.index === index) {
+      const deltaY = event.clientY - pointerRef.current.y
+      if (deltaY < -70 && selected.length === 1 && selected[0] === index) {
+        handlePlay({ viaDrop: false })
+      }
+    }
+    pointerRef.current = null
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (cards.length === 0) return
+    if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      const next = (focusIndex + 1) % cards.length
+      setFocusIndex(next)
+      buttonsRef.current[next]?.focus()
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      const next = (focusIndex - 1 + cards.length) % cards.length
+      setFocusIndex(next)
+      buttonsRef.current[next]?.focus()
+    } else if (event.key === ' ') {
+      event.preventDefault()
+      toggle(focusIndex)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      handlePlay({ viaDrop: false })
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      handleClear()
+    }
+  }
+
+  const selectionSuit = leaderMode && selected.length > 0 ? cards[selected[0]].suit : null
 
   return (
-    <div className="hand" ref={containerRef}>
-      <div className="hand-hint">
-        {requiredCount
-          ? `Нужно выложить ${requiredCount} ${requiredCount === 1 ? 'карту' : 'карты'}`
-          : 'Выберите до трёх карт одной масти для хода'}
+    <div
+      className={`hand ${dragging ? 'dragging' : ''}`}
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="hand-header">
+        <div className="hand-hint">
+          {leaderMode
+            ? 'Вы лидер: выберите до трёх карт одной масти'
+            : `Ответьте набором из ${requiredCount} карт`}
+        </div>
+        <div className="hand-meta">
+          {trick && (
+            <>
+              <span className="pill">Нужно: {trick.required_count}</span>
+              <span className="pill">Беру: {ownerLabel}</span>
+            </>
+          )}
+        </div>
       </div>
+      <div className={`hand-feedback ${error ? 'error' : ''}`}>{helperText}</div>
       <div className="hand-cards">
         {cards.map((card, index) => {
           const isSelected = selected.includes(index)
+          const incompatible = Boolean(selectionSuit && card.suit !== selectionSuit)
           return (
             <button
               key={`${card.suit}${card.rank}-${index}`}
               type="button"
-              className={`hand-card ${isSelected ? 'selected' : ''}`}
-              onClick={()=>toggle(index)}
-              disabled={!isMyTurn && !isSelected}
+              ref={el => {
+                buttonsRef.current[index] = el
+              }}
+              className={`hand-card ${isSelected ? 'selected' : ''} ${incompatible ? 'incompatible' : ''}`}
+              onClick={() => toggle(index)}
+              onDoubleClick={() => handleDoubleClick(index)}
+              draggable={Boolean(isMyTurn)}
+              onDragStart={event => handleDragStart(index, event)}
+              onDragEnd={handleDragEnd}
+              onPointerDown={event => handlePointerDown(index, event)}
+              onPointerUp={event => handlePointerUp(index, event)}
             >
               <CardView card={card} />
             </button>
@@ -98,9 +396,14 @@ export default function Hand({ cards, requiredCount, isMyTurn, onPlay }: Props) 
         })}
       </div>
       <div className="hand-actions">
-        <button className="chip" onClick={()=> setSelected([])}>Сбросить выбор</button>
-        <button className="button primary" disabled={!isSelectionValid} onClick={handlePlay}>
-          Сыграть выбранные карты
+        <button className="chip" onClick={handleClear} type="button">
+          Очистить выбор
+        </button>
+        <button className="chip" onClick={() => applyHint()} type="button">
+          Подсказка
+        </button>
+        <button className="button primary" disabled={!canSubmit} onClick={() => handlePlay({ viaDrop: false })}>
+          Сыграть
         </button>
       </div>
     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -289,3 +289,58 @@ html[data-theme="dark"] .pill{ background:rgba(255,255,255,.08); color:var(--fg)
 
 .card.red .card-rank,
 .card.red .card-suit{ color:#d33; }
+
+/* ===== New game table layout ===== */
+.table-layout{display:grid;gap:16px;margin-top:12px}
+.table-indicators{display:flex;flex-wrap:wrap;gap:8px}
+.indicator{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--card);font-size:12px;color:var(--muted)}
+.indicator.timer.active{color:var(--primary);border-color:var(--primary)}
+.table-opponents{display:flex;flex-wrap:wrap;gap:12px;justify-content:center}
+.player-chip{position:relative;min-width:120px;padding:10px 12px;border:1px solid var(--border);border-radius:14px;background:var(--card);display:grid;gap:4px;text-align:center;transition:transform .15s ease,box-shadow .15s ease}
+.player-chip.turn{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 25%,transparent);transform:translateY(-2px)}
+.player-chip.me{border-style:dashed}
+.chip-name{font-weight:700;font-size:14px}
+.chip-count{font-size:12px;color:var(--muted)}
+.chip-owner{position:absolute;top:-10px;right:-10px;background:var(--primary);color:var(--primary-fg);padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;box-shadow:0 2px 6px rgba(0,0,0,.2)}
+
+.trick-area{position:relative;border:2px dashed var(--border);border-radius:18px;padding:16px;display:grid;gap:12px;min-height:200px;background:color-mix(in srgb,var(--card) 85%, transparent)}
+.trick-area.drop-active{border-color:var(--primary);background:color-mix(in srgb,var(--primary) 12%, var(--card) 88%)}
+.trick-row{display:grid;grid-template-columns:120px 1fr 80px;align-items:center;gap:12px;padding:6px 8px;border-radius:12px;background:rgba(0,0,0,.02)}
+html[data-theme="dark"] .trick-row{background:rgba(255,255,255,.04)}
+.trick-row.owner{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 35%, transparent)}
+.trick-player{font-weight:700}
+.trick-slots{display:flex;gap:8px;flex-wrap:wrap}
+.trick-slot{width:72px;height:104px;border:1px dashed var(--border);border-radius:10px;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.03)}
+html[data-theme="dark"] .trick-slot{background:rgba(255,255,255,.04)}
+.slot-placeholder{width:100%;height:100%;border-radius:inherit;background:rgba(0,0,0,.05)}
+.trick-outcome{font-size:12px;color:var(--muted);text-align:right}
+.trick-empty{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--muted);font-size:14px}
+.drop-hint{position:absolute;bottom:16px;right:16px;padding:8px 14px;border-radius:999px;background:var(--primary);color:var(--primary-fg);font-size:12px;font-weight:700;animation:pulse 1.2s ease-in-out infinite}
+@keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.05);}100%{transform:scale(1);}}
+
+.table-summary{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
+.summary-panel{border:1px solid var(--border);border-radius:14px;background:var(--card);display:grid}
+.panel-title{padding:10px 12px;font-weight:700;border-bottom:1px solid var(--border)}
+.panel-body{padding:10px 12px;display:grid;gap:6px}
+.summary-row{display:flex;justify-content:space-between;font-size:13px}
+.combo-row{display:flex;justify-content:space-between;font-size:13px}
+
+/* ===== Hand ===== */
+.hand{display:grid;gap:12px;padding:12px;border:1px solid var(--border);border-radius:18px;background:var(--card);outline:none;transition:box-shadow .2s ease}
+.hand.dragging{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 25%, transparent)}
+.hand-header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap}
+.hand-hint{font-weight:700;font-size:14px}
+.hand-meta{display:flex;gap:8px;flex-wrap:wrap}
+.hand-feedback{font-size:13px;color:var(--muted);min-height:18px}
+.hand-feedback.error{color:#d33;animation:shake .18s linear 2}
+@keyframes shake{0%,100%{transform:translateX(0);}25%{transform:translateX(-4px);}75%{transform:translateX(4px);}}
+.hand-cards{display:flex;flex-wrap:wrap;gap:10px}
+.hand-card{border:none;background:transparent;padding:0;cursor:pointer;position:relative;transition:transform .15s ease}
+.hand-card.selected{transform:translateY(-8px)}
+.hand-card.incompatible{opacity:.4}
+.hand-card:focus-visible{outline:2px solid var(--primary);outline-offset:4px}
+.hand-actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:flex-end}
+
+.card.hidden{background:repeating-linear-gradient(45deg,rgba(0,0,0,.08),rgba(0,0,0,.08) 6px,rgba(0,0,0,0) 6px,rgba(0,0,0,0) 12px);color:var(--muted)}
+.card.muted{opacity:.7}
+.card.red .card-rank,.card.red .card-suit{color:#c23838}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,8 +1,17 @@
 export type Suit = '♠'|'♥'|'♦'|'♣'
 export type Card = { suit: Suit; rank: number }
-export type TrickPlayOutcome = 'lead'|'beat'|'discard'
-export type TrickPlay = { player_id: string; cards: Card[]; outcome: TrickPlayOutcome }
-export type TrickState = { leader_id: string; owner_id: string; required_count: number; plays: TrickPlay[] }
+export type PublicCard = Card | { hidden: true }
+export type TrickPlayOutcome = 'lead'|'beat'|'partial'|'discard'
+export type TrickPlay = { player_id: string; seat: number; cards: PublicCard[]; outcome: TrickPlayOutcome; owner: boolean }
+export type TrickState = {
+  leader_id: string
+  leader_seat: number
+  owner_id: string
+  owner_seat: number
+  required_count: number
+  trick_index: number
+  plays: TrickPlay[]
+}
 export type Announcement = { player_id: string; combo: 'bura'|'molodka'|'moscow'|'four_ends'; cards: Card[] }
 export type DiscardVisibility = 'open'|'faceDown'
 export type TableConfig = {
@@ -23,9 +32,10 @@ export type GameState = {
   me?: Player
   trump?: Suit
   trump_card?: Card
-  table_cards: Card[]
+  table_cards: PublicCard[]
   deck_count: number
   hands?: Card[]
+  hand_counts?: Record<string, number>
   turn_player_id?: string
   winner_id?: string
   scores?: Record<string, number>
@@ -37,6 +47,7 @@ export type GameState = {
   announcements?: Announcement[]
   turn_deadline_ts?: number
   round_number?: number
+  round_id?: string
   match_over?: boolean
   winners?: string[]
   losers?: string[]


### PR DESCRIPTION
## Summary
- refactor backend trick handling to track owner seats, partial beats, round ids and hand counts
- expose new play_cards websocket contract and update turn serialization for public card masking
- redesign the table UI with drag-and-drop trick grid, enhanced hand selection with hints, and refreshed styling

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c1d734008332abc53634cf198706