### PR TITLE
Update uvicorn dependency for websocket support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.115.0
-uvicorn==0.30.6
+uvicorn[standard]==0.30.6
 python-multipart==0.0.9
 pydantic==2.9.0
 itsdangerous==2.2.0


### PR DESCRIPTION
## Summary
- update the backend requirements to install uvicorn with the standard extras for websocket support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d23fad17888332b340d2dc19635d09