### PR TITLE
feat: adapt typography and cards to viewport

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Hand from './components/Hand'
 import { getState, verify } from './api'
 import type { GameState, Card } from './types'
 import { applyThemeOnce, watchTelegramTheme } from './theme'
+import { initViewportSizing } from './viewport'
 import { createRoomChannel, type RoomChannel } from './room-channel'
 import GameRules from './components/GameRules'
 
@@ -32,6 +33,10 @@ export default function App(){
   useEffect(() => {
     applyThemeOnce()
     watchTelegramTheme()
+    const disposeViewport = initViewportSizing()
+    return () => {
+      disposeViewport?.()
+    }
   }, [])
 
   // Telegram auth (с безопасным фолбэком)

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,9 +1,29 @@
-:root { font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif; }
-body { margin: 0; }
-.app { padding: 12px; }
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --app-scale: 1;
+  --app-base-font: clamp(14px, 11px + 1.2vw, 18px);
+  --font-3xs: calc(11px * var(--app-scale));
+  --font-2xs: calc(12px * var(--app-scale));
+  --font-xs: calc(13px * var(--app-scale));
+  --font-sm: calc(14px * var(--app-scale));
+  --font-md: calc(15px * var(--app-scale));
+  --font-lg: calc(16px * var(--app-scale));
+  --font-xl: calc(18px * var(--app-scale));
+  --font-2xl: calc(20px * var(--app-scale));
+  --font-3xl: calc(28px * var(--app-scale));
+  --card-width: calc(68px * var(--app-scale));
+  --card-height: calc(96px * var(--app-scale));
+  --card-small-width: calc(48px * var(--app-scale));
+  --card-small-height: calc(72px * var(--app-scale));
+  --card-back-width: calc(42px * var(--app-scale));
+  --card-back-height: calc(60px * var(--app-scale));
+  --card-large-width: calc(72px * var(--app-scale));
+  --card-large-height: calc(104px * var(--app-scale));
+}
+html { font-size: var(--app-base-font); }
+body { margin: 0; min-height: var(--app-vh-stable, 100vh); }
+.app { padding: 0.75rem; }
 .row { display: flex; gap: 8px; align-items: center; }
-.card { width: 56px; height: 84px; border-radius: 8px; border: 1px solid #ccc; display: grid; place-items: center; background: white; transition: transform .2s ease; }
-.card:hover { transform: translateY(-4px); }
 .hand { display: flex; gap: 6px; flex-wrap: wrap; }
 .table { display: flex; gap: 8px; padding: 8px; min-height: 100px; border: 1px dashed #ccc; border-radius: 12px; }
 .badge { padding: 2px 8px; border-radius: 999px; background: #eee; }
@@ -23,7 +43,7 @@ body { margin: 0; }
 .opponents{display:flex;justify-content:center;gap:32}
 .opponent-slot{display:flex;gap:6}
 .card-back{
-  width:42px;height:60px;border-radius:8px;
+  width:var(--card-back-width);height:var(--card-back-height);border-radius:0.5rem;
   background:linear-gradient(135deg,#7b8bff,#a1b1ff);
   border:1px solid rgba(0,0,0,.15);
   box-shadow:0 2px 6px rgba(0,0,0,.12);
@@ -34,18 +54,19 @@ body { margin: 0; }
 }
 .table-cards{display:flex;gap:8;min-height:80px;align-items:center}
 .card{
-  width:56px;height:80px;border-radius:10px;background:#fff;
+  width:var(--card-width);height:calc(var(--card-height) * 0.833);border-radius:0.625rem;background:#fff;
   border:1px solid rgba(0,0,0,.15);
   display:flex;flex-direction:column;align-items:center;justify-content:center;
   box-shadow:0 2px 8px rgba(0,0,0,.12);
   user-select:none
 }
+.card:hover{ transform: translateY(-0.25rem); }
 .card .rank{font-weight:800}
-.card .suit{font-size:22px;line-height:1;margin-top:2px}
+.card .suit{font-size:calc(var(--font-xl) * 1.1);line-height:1;margin-top:0.125rem}
 .card .suit.red{color:#d33}
 .card.on-table{transform:rotate(-2deg)}
 .trump{display:flex;flex-direction:column;align-items:center;gap:6}
-.trump-title{font-size:12px;opacity:.7}
+.trump-title{font-size:var(--font-2xs);opacity:.7}
 .trump-card{transform:rotate(8deg)}
 .trump-card.ghost{background:#f5f5f5;color:#aaa}
 
@@ -55,13 +76,13 @@ body { margin: 0; }
 }
 .room-title{min-width:0}
 .room-name{font-weight:700}
-.room-sub{font-size:12px;opacity:.7}
+.room-sub{font-size:var(--font-2xs);opacity:.7}
 .room-meta{display:flex;gap:8;align-items:center;justify-content:flex-end}
 .room-actions{display:flex;gap:8}
 .badge.warn{background:#fff7e6;border:1px solid #fde1a8}
 .controls{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
 .combo-panel{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.combo-title{font-size:12px;color:var(--muted);font-weight:600}
+.combo-title{font-size:var(--font-2xs);color:var(--muted);font-weight:600}
 .input{flex:1 1 auto;padding:10px 12px;border:1px solid #ddd;border-radius:10px}
 
 /* ======= THEME (light/dark) ======= */
@@ -99,23 +120,23 @@ body, .app{
   align-items:center; justify-content:center;
   gap: 16px; text-align:center;
 }
-.menu-title{ font-size: 28px; font-weight: 800; margin: 0 0 6px; }
+.menu-title{ font-size: var(--font-3xl); font-weight: 800; margin: 0 0 6px; }
 .menu-actions{ display:flex; gap: 12px; flex-wrap: wrap; justify-content:center; }
 .btn-xl{
   padding: 14px 20px; border-radius: 14px; border:1px solid var(--border);
-  background: var(--card); color: var(--fg); font-weight: 800; font-size: 16px;
+  background: var(--card); color: var(--fg); font-weight: 800; font-size: var(--font-lg);
 }
 .btn-xl.primary{ background: var(--primary); color: var(--primary-fg); border-color: var(--primary); }
 .btn-xl.ghost{ background: transparent; border-style: dashed; }
-.menu-note{ font-size: 12px; opacity: .7; }
+.menu-note{ font-size: var(--font-2xs); opacity: .7; }
 
 /* ======= PAGES ======= */
 .page-wrap{ display:grid; gap: 12px; padding: 12px; }
-.page-title{ font-size: 20px; font-weight: 800; margin: 2px 0 6px; }
+.page-title{ font-size: var(--font-2xl); font-weight: 800; margin: 2px 0 6px; }
 .link-btn{ background:none; border:none; color: var(--muted); text-decoration: underline; padding: 6px 0; }
-.rules{ display:grid; gap:14px; line-height:1.45; font-size:14px; }
+.rules{ display:grid; gap:14px; line-height:1.45; font-size:var(--font-sm); }
 .rules section{ display:grid; gap:6px; border:1px solid var(--border); border-radius:12px; padding:12px; background:var(--card); }
-.rules h3{ margin:0; font-size:15px; font-weight:700; }
+.rules h3{ margin:0; font-size:var(--font-md); font-weight:700; }
 .rules ul{ margin:0; padding-left:18px; display:grid; gap:4px; }
 
 /* ======= LOBBY ======= */
@@ -129,7 +150,7 @@ body, .app{
 }
 .room-head{ display:flex; flex-direction:column; gap:4px; }
 .room-name{ font-weight: 800; }
-.room-variant{ font-size: 12px; color: var(--muted); }
+.room-variant{ font-size: var(--font-2xs); color: var(--muted); }
 .room-meta{ display:flex; gap:8px; align-items:center; flex-wrap: wrap; }
 .button.full{ width:100%; }
 
@@ -141,11 +162,11 @@ body, .app{
 .button.primary{ background: var(--primary); color: var(--primary-fg); border-color: var(--primary); }
 .create-form{ display:grid; gap:16px; }
 .settings-section{ display:grid; gap:12px; }
-.section-title{ margin:0; font-size:16px; font-weight:800; }
+.section-title{ margin:0; font-size:var(--font-lg); font-weight:800; }
 .settings-grid{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .settings-card{ border:1px solid var(--border); border-radius:14px; padding:12px; background:var(--card); display:grid; gap:10px; }
 .settings-card legend{ font-weight:700; }
-.settings-note{ margin:0; font-size:12px; color: var(--muted); }
+.settings-note{ margin:0; font-size:var(--font-2xs); color: var(--muted); }
 .options-row{ display:flex; flex-wrap:wrap; gap:8px; }
 .option-chip{ display:inline-flex; align-items:center; gap:6px; padding:8px 12px; border:1px solid var(--border); border-radius:999px; cursor:pointer; }
 .option-chip input{ display:none; }
@@ -154,38 +175,38 @@ body, .app{
 .option-tile input{ display:none; }
 .option-tile.active{ border-color: var(--primary); box-shadow:0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent); }
 .option-title{ font-weight:700; }
-.option-desc{ font-size:12px; color:var(--muted); }
+.option-desc{ font-size:var(--font-2xs); color:var(--muted); }
 .switch{ display:flex; align-items:center; gap:8px; font-weight:700; cursor:pointer; }
 .switch input{ width:18px; height:18px; }
 .form-summary{ border:1px solid var(--border); border-radius:14px; padding:12px; background:var(--card); display:grid; gap:6px; }
 .summary-title{ font-weight:700; }
-.summary-text{ font-size:13px; color:var(--muted); }
+.summary-text{ font-size:var(--font-xs); color:var(--muted); }
 .badge{
   display:inline-flex; align-items:center; gap:6px;
-  padding:6px 10px; border-radius: 999px; border:1px solid var(--border); background: var(--card); color: var(--muted); font-size: 12px;
+  padding:6px 10px; border-radius: 999px; border:1px solid var(--border); background: var(--card); color: var(--muted); font-size: var(--font-2xs);
 }
 .badge.strong{ color: var(--fg); font-weight: 700; }
 
 /* (Существующие стили стола/карт остаются; темы применятся за счёт переменных) */
 
 /* ===== Cards ===== */
-.card{
-  width: 68px; height: 96px;
-  border-radius: 10px;
+.card{ 
+  width: var(--card-width); height: var(--card-height);
+  border-radius: 0.625rem;
   border: 1px solid var(--border);
   background: var(--card);
   display:flex; flex-direction:column; align-items:center; justify-content:center;
   box-shadow: 0 2px 6px rgba(0,0,0,.08);
   transition: transform .15s ease, box-shadow .15s ease;
 }
-.card-rank{ font-weight: 800; font-size: 18px; line-height: 1; }
-.card-suit{ font-size: 18px; opacity: .9; }
+.card-rank{ font-weight: 800; font-size: var(--font-xl); line-height: 1; }
+.card-suit{ font-size: var(--font-xl); opacity: .9; }
 
 /* ===== Table ===== */
 .table-area{ position: relative; display:grid; gap:12px; }
 .pairs{ display:flex; flex-wrap: wrap; gap:12px; min-height: 112px; }
 .pair{ display:flex; gap:12px; align-items:center; }
-.cover-slot{ width:68px; height:96px; border:1px dashed var(--border); border-radius:10px; opacity:.5; }
+.cover-slot{ width:var(--card-width); height:var(--card-height); border:1px dashed var(--border); border-radius:0.625rem; opacity:.5; }
 
 .trump-panel{
   display:flex; align-items:center; gap:10px;
@@ -209,7 +230,7 @@ body, .app{
 /* ===== Hand ===== */
 .hand{ display:grid; gap:12px; padding:12px; border:1px solid var(--border); border-radius:16px; background:var(--card); }
 .hand.deal-anim .hand-card{ animation: deal .35s ease both; }
-.hand-hint{ font-size:12px; color:var(--muted); }
+.hand-hint{ font-size:var(--font-2xs); color:var(--muted); }
 .hand-cards{ display:flex; flex-wrap:wrap; gap:8px; }
 .hand-card{ border:none; background:none; padding:0; cursor:pointer; position:relative; }
 .hand-card.selected::after{
@@ -221,7 +242,7 @@ body, .app{
 }
 .hand-card:disabled{ opacity:.5; cursor:not-allowed; }
 .hand-actions{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-.chip{ padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); cursor:pointer; font-size:12px; }
+.chip{ padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); cursor:pointer; font-size:var(--font-2xs); }
 .chip:disabled{ opacity:.5; cursor:not-allowed; }
 
 @keyframes deal{
@@ -233,56 +254,56 @@ body, .app{
 .game-page{ display:grid; gap:16px; padding:12px; }
 .game-hud{ display:flex; flex-direction:column; gap:8px; padding:12px; border:1px solid var(--border); border-radius:16px; background:var(--card); }
 .hud-primary{ display:grid; gap:2px; }
-.hud-title{ font-size:20px; font-weight:800; }
-.hud-sub{ font-size:12px; color:var(--muted); }
+.hud-title{ font-size:var(--font-2xl); font-weight:800; }
+.hud-sub{ font-size:var(--font-2xs); color:var(--muted); }
 .hud-stats{ display:flex; flex-wrap:wrap; gap:8px; }
-.pill{ display:inline-flex; align-items:center; gap:4px; padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.06); color:var(--muted); font-size:12px; }
+.pill{ display:inline-flex; align-items:center; gap:4px; padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.06); color:var(--muted); font-size:var(--font-2xs); }
 html[data-theme="dark"] .pill{ background:rgba(255,255,255,.08); color:var(--fg); }
 
 
 .table-layout{ display:grid; gap:16px; padding:12px; border:1px solid var(--border); border-radius:20px; background:var(--card); box-shadow:0 12px 28px rgba(0,0,0,.12); }
 .score-row{ display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
-.score-chip{ padding:8px 12px; border-radius:16px; background:rgba(0,0,0,.05); color:var(--muted); font-size:12px; display:grid; gap:4px; transition:all .2s ease; min-width:140px; }
+.score-chip{ padding:8px 12px; border-radius:16px; background:rgba(0,0,0,.05); color:var(--muted); font-size:var(--font-2xs); display:grid; gap:4px; transition:all .2s ease; min-width:140px; }
 .score-chip.active{ background:var(--primary); color:var(--primary-fg); }
-.score-name{ font-weight:700; font-size:13px; }
+.score-name{ font-weight:700; font-size:var(--font-xs); }
 .score-value{ font-weight:600; }
-.score-sub{ font-size:11px; opacity:.8; }
+.score-sub{ font-size:var(--font-3xs); opacity:.8; }
 
 .table-status{ display:flex; flex-wrap:wrap; gap:8px; }
-.status-pill{ padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.05); font-size:12px; color:var(--muted); }
+.status-pill{ padding:6px 10px; border-radius:999px; background:rgba(0,0,0,.05); font-size:var(--font-2xs); color:var(--muted); }
 .status-pill.timer{ font-weight:700; }
 .status-pill.timer.active{ background:var(--primary); color:var(--primary-fg); }
 
 .plays-board{ display:grid; gap:10px; border:1px dashed var(--border); border-radius:16px; padding:12px; background:color-mix(in srgb, var(--card) 80%, transparent); }
 .plays-header{ display:flex; gap:8px; align-items:center; justify-content:space-between; }
 .plays-title{ font-weight:700; }
-.plays-placeholder{ font-size:12px; color:var(--muted); }
+.plays-placeholder{ font-size:var(--font-2xs); color:var(--muted); }
 .play-row{ display:grid; grid-template-columns: 120px 1fr auto; gap:8px; align-items:center; padding:6px 8px; border-radius:10px; background:rgba(0,0,0,.04); }
 .play-row.owner{ border:1px solid var(--primary); box-shadow:0 0 0 2px color-mix(in srgb, var(--primary) 15%, transparent); }
-.play-player{ font-weight:600; font-size:13px; }
+.play-player{ font-weight:600; font-size:var(--font-xs); }
 .play-cards{ display:flex; gap:6px; flex-wrap:wrap; }
-.play-outcome{ font-size:12px; font-weight:600; }
+.play-outcome{ font-size:var(--font-2xs); font-weight:600; }
 .play-outcome.outcome-discard{ color:#d9534f; }
 
 .info-panels{ display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .panel{ border:1px solid var(--border); border-radius:16px; padding:12px; background:var(--card); display:grid; gap:8px; }
-.panel-title{ font-weight:700; font-size:13px; }
-.panel-body{ display:flex; flex-wrap:wrap; gap:6px; font-size:12px; }
-.discard-cards .card{ width:48px; height:72px; }
+.panel-title{ font-weight:700; font-size:var(--font-xs); }
+.panel-body{ display:flex; flex-wrap:wrap; gap:6px; font-size:var(--font-2xs); }
+.discard-cards .card{ width:var(--card-small-width); height:var(--card-small-height); }
 .muted{ color:var(--muted); }
 .combos{ flex-direction:column; align-items:flex-start; }
-.combo-entry{ display:flex; gap:6px; font-size:12px; background:rgba(0,0,0,.05); padding:4px 8px; border-radius:10px; }
+.combo-entry{ display:flex; gap:6px; font-size:var(--font-2xs); background:rgba(0,0,0,.05); padding:4px 8px; border-radius:10px; }
 .combo-player{ font-weight:600; }
 .combo-name{ font-weight:700; }
 
 .round-summary{ margin-top:-4px; }
 .round-points{ display:grid; gap:6px; }
-.round-point-row{ display:flex; justify-content:space-between; font-size:13px; }
+.round-point-row{ display:flex; justify-content:space-between; font-size:var(--font-xs); }
 .match-result .panel-body{ flex-direction:column; align-items:flex-start; gap:6px; }
-.result-line{ display:flex; gap:6px; font-size:13px; }
+.result-line{ display:flex; gap:6px; font-size:var(--font-xs); }
 
 .hand-wrap{ display:grid; gap:8px; }
-.hand-title{ margin:0; font-size:14px; font-weight:700; }
+.hand-title{ margin:0; font-size:var(--font-sm); font-weight:700; }
 
 @keyframes drop-attack{ from{ transform:translate(-50%, -70%) rotate(-10deg); opacity:0; } to{ transform:translate(-50%, -50%) rotate(-4deg); opacity:1; } }
 @keyframes cover-card{ from{ transform:translate(-50%, -30%) rotate(20deg); opacity:0; } to{ transform:translate(-50%, -50%) rotate(10deg); opacity:1; } }
@@ -293,15 +314,15 @@ html[data-theme="dark"] .pill{ background:rgba(255,255,255,.08); color:var(--fg)
 /* ===== New game table layout ===== */
 .table-layout{display:grid;gap:16px;margin-top:12px}
 .table-indicators{display:flex;flex-wrap:wrap;gap:8px}
-.indicator{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--card);font-size:12px;color:var(--muted)}
+.indicator{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:var(--card);font-size:var(--font-2xs);color:var(--muted)}
 .indicator.timer.active{color:var(--primary);border-color:var(--primary)}
 .table-opponents{display:flex;flex-wrap:wrap;gap:12px;justify-content:center}
 .player-chip{position:relative;min-width:120px;padding:10px 12px;border:1px solid var(--border);border-radius:14px;background:var(--card);display:grid;gap:4px;text-align:center;transition:transform .15s ease,box-shadow .15s ease}
 .player-chip.turn{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 25%,transparent);transform:translateY(-2px)}
 .player-chip.me{border-style:dashed}
-.chip-name{font-weight:700;font-size:14px}
-.chip-count{font-size:12px;color:var(--muted)}
-.chip-owner{position:absolute;top:-10px;right:-10px;background:var(--primary);color:var(--primary-fg);padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;box-shadow:0 2px 6px rgba(0,0,0,.2)}
+.chip-name{font-weight:700;font-size:var(--font-sm)}
+.chip-count{font-size:var(--font-2xs);color:var(--muted)}
+.chip-owner{position:absolute;top:-10px;right:-10px;background:var(--primary);color:var(--primary-fg);padding:4px 8px;border-radius:999px;font-size:var(--font-3xs);font-weight:700;box-shadow:0 2px 6px rgba(0,0,0,.2)}
 
 .trick-area{position:relative;border:2px dashed var(--border);border-radius:18px;padding:16px;display:grid;gap:12px;min-height:200px;background:color-mix(in srgb,var(--card) 85%, transparent)}
 .trick-area.drop-active{border-color:var(--primary);background:color-mix(in srgb,var(--primary) 12%, var(--card) 88%)}
@@ -310,28 +331,28 @@ html[data-theme="dark"] .trick-row{background:rgba(255,255,255,.04)}
 .trick-row.owner{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 35%, transparent)}
 .trick-player{font-weight:700}
 .trick-slots{display:flex;gap:8px;flex-wrap:wrap}
-.trick-slot{width:72px;height:104px;border:1px dashed var(--border);border-radius:10px;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.03)}
+.trick-slot{width:var(--card-large-width);height:var(--card-large-height);border:1px dashed var(--border);border-radius:0.625rem;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.03)}
 html[data-theme="dark"] .trick-slot{background:rgba(255,255,255,.04)}
 .slot-placeholder{width:100%;height:100%;border-radius:inherit;background:rgba(0,0,0,.05)}
-.trick-outcome{font-size:12px;color:var(--muted);text-align:right}
-.trick-empty{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--muted);font-size:14px}
-.drop-hint{position:absolute;bottom:16px;right:16px;padding:8px 14px;border-radius:999px;background:var(--primary);color:var(--primary-fg);font-size:12px;font-weight:700;animation:pulse 1.2s ease-in-out infinite}
+.trick-outcome{font-size:var(--font-2xs);color:var(--muted);text-align:right}
+.trick-empty{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--muted);font-size:var(--font-sm)}
+.drop-hint{position:absolute;bottom:16px;right:16px;padding:8px 14px;border-radius:999px;background:var(--primary);color:var(--primary-fg);font-size:var(--font-2xs);font-weight:700;animation:pulse 1.2s ease-in-out infinite}
 @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.05);}100%{transform:scale(1);}}
 
 .table-summary{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
 .summary-panel{border:1px solid var(--border);border-radius:14px;background:var(--card);display:grid}
 .panel-title{padding:10px 12px;font-weight:700;border-bottom:1px solid var(--border)}
 .panel-body{padding:10px 12px;display:grid;gap:6px}
-.summary-row{display:flex;justify-content:space-between;font-size:13px}
-.combo-row{display:flex;justify-content:space-between;font-size:13px}
+.summary-row{display:flex;justify-content:space-between;font-size:var(--font-xs)}
+.combo-row{display:flex;justify-content:space-between;font-size:var(--font-xs)}
 
 /* ===== Hand ===== */
 .hand{display:grid;gap:12px;padding:12px;border:1px solid var(--border);border-radius:18px;background:var(--card);outline:none;transition:box-shadow .2s ease}
 .hand.dragging{box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 25%, transparent)}
 .hand-header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap}
-.hand-hint{font-weight:700;font-size:14px}
+.hand-hint{font-weight:700;font-size:var(--font-sm)}
 .hand-meta{display:flex;gap:8px;flex-wrap:wrap}
-.hand-feedback{font-size:13px;color:var(--muted);min-height:18px}
+.hand-feedback{font-size:var(--font-xs);color:var(--muted);min-height:18px}
 .hand-feedback.error{color:#d33;animation:shake .18s linear 2}
 @keyframes shake{0%,100%{transform:translateX(0);}25%{transform:translateX(-4px);}75%{transform:translateX(4px);}}
 .hand-cards{display:flex;flex-wrap:wrap;gap:10px}

--- a/frontend/src/viewport.ts
+++ b/frontend/src/viewport.ts
@@ -1,0 +1,64 @@
+declare global {
+  interface Window {
+    Telegram?: any
+  }
+}
+
+type Numeric = number | undefined | null
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function resolveNumber(value: Numeric, fallback: number): number {
+  const num = typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  return num ?? fallback
+}
+
+/**
+ * Updates CSS custom properties related to viewport sizing and adaptive scale.
+ * Используем данные Telegram WebApp API (если доступны) и window.
+ */
+function applyViewportVars() {
+  const tg = window.Telegram?.WebApp
+  const width = resolveNumber(tg?.viewportWidth, window.innerWidth)
+  const height = resolveNumber(tg?.viewportHeight, window.innerHeight)
+  const stableHeight = resolveNumber(tg?.viewportStableHeight, height)
+
+  const docStyle = document.documentElement.style
+  docStyle.setProperty('--app-vw', `${Math.round(width)}px`)
+  docStyle.setProperty('--app-vh', `${Math.round(height)}px`)
+  docStyle.setProperty('--app-vh-stable', `${Math.round(stableHeight)}px`)
+
+  // Рассчитываем коэффициент масштабирования интерфейса.
+  const clampedWidth = clamp(width, 320, 1024)
+  const scale = clamp(0.9 + ((clampedWidth - 320) / (1024 - 320)) * 0.4, 0.9, 1.3)
+  docStyle.setProperty('--app-scale', scale.toFixed(3))
+
+  const baseFont = clamp(14 + ((clampedWidth - 320) / (768 - 320)) * 4, 14, 18)
+  docStyle.setProperty('--app-base-font', `${baseFont.toFixed(2)}px`)
+}
+
+/**
+ * Настраивает реакцию на изменение размеров вьюпорта Telegram/браузера.
+ */
+export function initViewportSizing() {
+  applyViewportVars()
+
+  const resizeHandler = () => applyViewportVars()
+  window.addEventListener('resize', resizeHandler)
+
+  const vv = window.visualViewport
+  vv?.addEventListener('resize', resizeHandler)
+
+  const tg = window.Telegram?.WebApp
+  const handleTelegramViewport = () => applyViewportVars()
+  tg?.onEvent?.('viewportChanged', handleTelegramViewport)
+
+  return () => {
+    window.removeEventListener('resize', resizeHandler)
+    vv?.removeEventListener('resize', resizeHandler)
+    tg?.offEvent?.('viewportChanged', handleTelegramViewport)
+  }
+}
+


### PR DESCRIPTION
## Summary
- initialize viewport listeners to mirror Telegram WebApp metrics in CSS variables
- scale base font size, typography tokens, and card dimensions with viewport-dependent CSS custom properties
- refactor styles to reuse the new variables so text and cards grow on larger displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d2848de6a883328efe0a559387db48