### PR TITLE
Fix Telegram init data verification

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,13 +1,18 @@
-import hmac, hashlib, os
-from urllib.parse import parse_qsl
+import hmac
+import hashlib
+import os
 from typing import Dict
+from urllib.parse import parse_qsl
+
 from dotenv import load_dotenv
 
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN","")
 
 def _get_secret_key() -> bytes:
-    return hashlib.sha256(("WebAppData"+BOT_TOKEN).encode()).digest()
+    """Return the Telegram secret key for validating init data."""
+
+    return hmac.new(b"WebAppData", BOT_TOKEN.encode(), hashlib.sha256).digest()
 
 def verify_init_data(init_data: str) -> Dict[str,str]:
     if not BOT_TOKEN:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,42 @@
+import hmac
+import hashlib
+import importlib
+from urllib.parse import urlencode
+
+import pytest
+
+
+def _build_init_data(bot_token: str, data: dict) -> str:
+    secret_key = hmac.new(b"WebAppData", bot_token.encode(), hashlib.sha256).digest()
+    data_check_string = "\n".join(f"{k}={data[k]}" for k in sorted(data))
+    data_hash = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    return urlencode({**data, "hash": data_hash})
+
+
+def test_verify_init_data_success(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:ABC")
+    import auth
+
+    importlib.reload(auth)
+
+    init_pairs = {
+        "auth_date": "1700000000",
+        "query_id": "AAEAAKZ-Hg",
+        "user": '{"id":1,"first_name":"Test"}',
+    }
+
+    init_data = _build_init_data("123:ABC", init_pairs)
+
+    assert auth.verify_init_data(init_data) == init_pairs
+
+
+def test_verify_init_data_invalid_hash(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:ABC")
+    import auth
+
+    importlib.reload(auth)
+
+    invalid_data = "auth_date=1&hash=deadbeef"
+
+    with pytest.raises(ValueError, match="hash mismatch"):
+        auth.verify_init_data(invalid_data)


### PR DESCRIPTION
## Summary
- compute the Telegram Web App secret key using the documented HMAC procedure
- add regression tests to ensure init data validation succeeds with valid hashes and fails otherwise

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ded470568c83329cea070ebbcea8c7