### PR TITLE
Restore card image proportions for four-card rows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -396,7 +396,7 @@ export default function App(){
           />
 
           {state.hands && (
-            <section className="hand-wrap">
+            <section className="hand-wrap section-hand">
               <h4 className="hand-title">Твои карты</h4>
               <Hand
                 cards={state.hands}

--- a/frontend/src/components/Hand.tsx
+++ b/frontend/src/components/Hand.tsx
@@ -434,7 +434,7 @@ export default function Hand({ cards, trick, trump, isMyTurn, playStamp, onPlay,
         </div>
       </div>
       <div className={`hand-feedback ${error ? 'error' : ''}`}>{helperText}</div>
-      <div className="hand-cards">
+      <div className="hand-cards cards-row">
         {cards.map((card, index) => {
           const isSelected = selected.includes(index)
           const incompatible = Boolean(selectionSuit && card.suit !== selectionSuit)

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -178,7 +178,7 @@ export default function TableView({ state, meId, dragPreview, onDropPlay, cardAs
         onDragOver={handleDragOver}
         onDrop={handleDrop}
       >
-        <div className="lane attacker">
+        <div className="lane cards-row attacker">
           {board.attacker.map(card => {
             const asset = cardAssets.get(card.cardId) ?? {
               id: card.cardId,
@@ -199,13 +199,17 @@ export default function TableView({ state, meId, dragPreview, onDropPlay, cardAs
               />
             )
           })}
-          {previewCards.map(card => (
-            <CardView key={`preview-${card.id}`} cardId={card.id} faceUp asset={card} muted />
-          ))}
+          {previewCards.length > 0 && (
+            <div className="lane-preview" aria-hidden="true">
+              {previewCards.map(card => (
+                <CardView key={`preview-${card.id}`} cardId={card.id} faceUp asset={card} muted />
+              ))}
+            </div>
+          )}
         </div>
 
         {board.defender.length > 0 && (
-          <div className="lane defender">
+          <div className="lane cards-row defender">
             {board.defender.map(card => {
               const asset = cardAssets.get(card.cardId) ?? {
                 id: card.cardId,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -11,6 +11,9 @@
   --font-xl: calc(18px * var(--app-scale));
   --font-2xl: calc(20px * var(--app-scale));
   --font-3xl: calc(28px * var(--app-scale));
+  --card-w: 60px;
+  --card-scale: 0.9;
+  --card-height-ratio: calc(5 / 3);
   --card-width: calc(68px * var(--app-scale));
   --card-height: calc(96px * var(--app-scale));
   --card-small-width: calc(48px * var(--app-scale));
@@ -246,7 +249,9 @@ body, .app{
 .hand{ display:grid; gap:12px; padding:12px; border:1px solid var(--border); border-radius:16px; background:var(--card); }
 .hand.deal-anim .hand-card{ animation: deal .35s ease both; }
 .hand-hint{ font-size:var(--font-2xs); color:var(--muted); }
-.hand-cards{ display:flex; flex-wrap:wrap; gap:8px; }
+.hand-cards{
+  display:grid;
+}
 .hand-card{ border:none; background:none; padding:0; cursor:pointer; position:relative; }
 .hand-card.selected::after{
   content:'';
@@ -299,6 +304,21 @@ body, .app{
 .drop-hint{ position:absolute; left:12px; right:12px; bottom:8px; text-align:center; font-size:var(--font-2xs); color:var(--muted); }
 
 .hand-wrap{ border:1px solid var(--border); border-radius:16px; padding:12px; background:var(--card); display:grid; gap:8px; box-shadow:0 6px 20px rgba(0,0,0,.08); }
+.section-hand { padding-left: 10px; padding-right: 10px; }
+.cards-row {
+  display: grid;
+  grid-template-columns: repeat(4, max-content);
+  justify-content: space-between;
+  gap: 6px;
+  padding: 0 8px;
+  justify-items: center;
+  align-items: center;
+}
+
+@media (max-width: 375px) {
+  .section-hand { padding-left: 8px; padding-right: 8px; }
+  .cards-row { gap: 4px; padding: 0 6px; }
+}
 .hand-title{ margin:0; font-size:var(--font-lg); font-weight:700; }
 
 .scoreboard{ border:1px solid var(--border); border-radius:16px; background:var(--card); box-shadow:0 6px 20px rgba(0,0,0,.08); overflow:hidden; }
@@ -318,14 +338,29 @@ body, .app{
 .hand-feedback{font-size:var(--font-xs);color:var(--muted);min-height:18px}
 .hand-feedback.error{color:#d33;animation:shake .18s linear 2}
 @keyframes shake{0%,100%{transform:translateX(0);}25%{transform:translateX(-4px);}75%{transform:translateX(4px);}}
-.hand-cards{--hand-gap:8px;--hand-card-width:clamp(72px,calc((100% - 3 * var(--hand-gap)) / 4),84px);display:grid;grid-template-columns:repeat(4,minmax(0,var(--hand-card-width)));justify-content:center;gap:var(--hand-gap);padding:8px 0}
-@media (max-width: 340px){.hand-cards{--hand-gap:6px}}
-.hand-card{border:none;background:transparent;padding:0;cursor:pointer;position:relative;transition:transform .15s ease;width:var(--hand-card-width);justify-self:center}
+.hand-cards{
+  --hand-card-width: 64px;
+  --card-w: var(--hand-card-width);
+}
+
+@media (max-width: 392px){
+  .hand-cards{
+    --hand-card-width: 60px;
+  }
+}
+
+@media (max-width: 375px){
+  .hand-cards{
+    --hand-card-width: 56px;
+  }
+}
+
+.hand-card{border:none;background:transparent;padding:0;cursor:pointer;position:relative;transition:transform .15s ease;width:calc(var(--card-w) * var(--card-scale));display:flex;align-items:stretch}
 .hand-card.selected{transform:translateY(-8px)}
 .hand-card.incompatible{opacity:.4}
 .hand-card:disabled{cursor:not-allowed;opacity:.6}
 .hand-card:disabled .card-image{box-shadow:0 4px 10px rgba(0,0,0,0.12)}
-.hand-card .card-image{width:100%;height:calc(var(--hand-card-width) * 1.4375)}
+.hand-card .card-image{width:100%;}
 .hand-card:focus-visible{outline:2px solid var(--primary);outline-offset:4px}
 .hand-actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:flex-end}
 
@@ -471,25 +506,24 @@ body, .app{
 }
 
 .lane {
-  display: flex;
-  gap: 10px;
-  overflow-x: auto;
-  padding-bottom: 4px;
+  --card-w: 60px;
+  position: relative;
+  min-height: calc(calc(var(--card-w) * var(--card-scale)) * var(--card-height-ratio));
 }
 
-.lane::-webkit-scrollbar {
-  height: 4px;
+@media (max-width: 392px) {
+  .lane {
+    --card-w: 56px;
+  }
 }
 
-.lane::-webkit-scrollbar-thumb {
-  background: var(--muted);
-  background: color-mix(in srgb, var(--primary) 25%, transparent);
-  border-radius: 999px;
+@media (max-width: 375px) {
+  .lane {
+    --card-w: 52px;
+  }
 }
 
 .card-image {
-  width: 64px;
-  height: 92px;
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
@@ -497,12 +531,25 @@ body, .app{
   flex: 0 0 auto;
   background: #f8f9ff;
   transition: transform 0.18s ease, box-shadow 0.18s ease;
+  width: calc(var(--card-w) * var(--card-scale));
+}
+
+.lane-preview {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: inherit;
+  gap: inherit;
+  justify-content: inherit;
+  justify-items: inherit;
+  align-content: center;
+  pointer-events: none;
 }
 
 .card-image img {
+  display: block;
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
 }
 
 .card-image.back {
@@ -557,32 +604,6 @@ body, .app{
   align-items: center;
   font-size: var(--font-2xs);
   color: var(--muted);
-}
-
-.hand-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
-  padding: 8px 2px;
-}
-
-.hand-card {
-  border: none;
-  background: transparent;
-  padding: 0;
-  border-radius: 14px;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-  flex: 0 0 auto;
-}
-
-.hand-card.selected {
-  transform: translateY(-8px);
-  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
-}
-
-.hand-card.incompatible {
-  opacity: 0.4;
 }
 
 .hand-actions {


### PR DESCRIPTION
## Summary
- restore card images to render with their natural aspect ratio while introducing a shared scale coefficient for fine tuning
- share a cards-row grid helper across the hand and table lanes so four cards always fit without horizontal scrolling
- trim hand section padding per breakpoint to maximize available width on small iPhone screens

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e240a3bd308332a35b0d46c5f3c0e3