### PR TITLE
Enable requesting early four-card turns from hand

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -492,6 +492,8 @@ export default function App(){
                 onDragPreview={setDragPreview}
                 isLocked={countdownActive}
                 lockReason="Ожидайте очистки стола"
+                canRequestEarlyTurn={canRequestEarlyTurn}
+                onRequestEarlyTurn={handleRequestEarlyTurn}
               />
             </section>
           )}


### PR DESCRIPTION
## Summary
- allow the hand UI to request an early turn when a valid four-card selection is made outside of your turn
- provide feedback while waiting for the early turn and automatically play once it is granted
- pass the early-turn request controls from the app shell down to the hand component

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b03166a88332829bef1965f2795f