### PR TITLE
Align card hierarchy with Bura rules

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -39,7 +39,10 @@ CARD_POINTS: Dict[int, int] = {
     11: 2,   # Jack
 }
 
-RANK_STRENGTH: Dict[int, int] = {rank: idx for idx, rank in enumerate(RANKS)}
+# Order from weakest to strongest following the game rules where the ten is
+# second only to the ace and trumps beat other suits.
+RANK_ORDER = [6, 7, 8, 9, 11, 12, 13, 10, 14]
+RANK_STRENGTH: Dict[int, int] = {rank: idx for idx, rank in enumerate(RANK_ORDER)}
 
 COMBINATION_NAMES = {
     "bura": "Бура",

--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -58,6 +58,13 @@ def test_partial_response_keeps_owner():
     assert room.taken_cards["A"] and len(room.taken_cards["A"]) == 4
 
 
+def test_ten_outranks_face_cards():
+    room = make_room()
+    assert room._beats(Card(suit="♠", rank=10), Card(suit="♠", rank=13))
+    assert room._beats(Card(suit="♠", rank=14), Card(suit="♠", rank=10))
+    assert not room._beats(Card(suit="♠", rank=13), Card(suit="♠", rank=10))
+
+
 def test_leader_can_throw_four_combo():
     room = make_room()
     room.hands["A"] = [

--- a/frontend/src/utils/earlyTurn.ts
+++ b/frontend/src/utils/earlyTurn.ts
@@ -1,6 +1,6 @@
 import type { Card, Suit } from '../types'
 
-const EARLY_RANK_ORDER = [14, 13, 12, 11, 10, 9, 8, 7, 6]
+const EARLY_RANK_ORDER = [14, 10, 13, 12, 11, 9, 8, 7, 6]
 const EARLY_RANK_LABEL: Record<number, string> = {
   6: '6',
   7: '7',


### PR DESCRIPTION
## Summary
- adjust the backend rank strength mapping so tens outrank face cards while aces remain highest
- update the frontend early turn ordering to mirror the new rank hierarchy
- add a regression test covering the updated beating logic

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e2cbf570e08332a0599d666e9354cd