### PR TITLE
Remove leader hint text from hand

### DIFF
--- a/frontend/src/components/Hand.tsx
+++ b/frontend/src/components/Hand.tsx
@@ -480,9 +480,7 @@ export default function Hand({
     >
       <div className="hand-header">
         <div className="hand-hint">
-          {leaderMode
-            ? 'Вы лидер: сыграйте до трёх карт одной масти или допустимую четвёрку'
-            : `Ответьте набором из ${requiredCount} карт`}
+          {leaderMode ? null : `Ответьте набором из ${requiredCount} карт`}
         </div>
         <div className="hand-meta">
           {trick && (


### PR DESCRIPTION
## Summary
- hide the leader-mode hint from the hand header so players no longer see the confusing instruction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ce00c2388332babc7c02ed662add