### PR TITLE
Add match summary screen and finalize penalty logic tests

### DIFF
--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -207,6 +207,28 @@ def test_penalties_and_round_summary():
     assert by_id["B"].points == 0
 
 
+def test_match_finishes_when_penalties_reach_twelve():
+    room = make_room()
+    room.scores = {"A": 0, "B": 8}
+    room.taken_cards = {
+        "A": [Card(suit="♠", rank=14), Card(suit="♠", rank=10)],
+        "B": [],
+    }
+    room.round_active = True
+
+    points = room._calculate_round_result()
+    penalties, leaders = room._calculate_penalties(points)
+    room._finalize_round(penalties, leaders)
+
+    assert room.match_over is True
+    assert room.scores["B"] == 14
+    assert room.losers == ["B"]
+    assert room.winners == ["A"]
+    assert room.winner_id == "A"
+    assert room.pending_round_start is False
+    assert room.started is False
+
+
 def test_round_start_alternates_between_players():
     variant = VARIANTS["classic_2p"]
     room = Room("r", "Test", variant)

--- a/frontend/src/components/MatchSummary.tsx
+++ b/frontend/src/components/MatchSummary.tsx
@@ -1,0 +1,66 @@
+import type { GameState } from '../types'
+import ScoreBoard from './ScoreBoard'
+
+type Props = {
+  state: GameState
+  meId?: string
+  onExit: () => void
+}
+
+function resolvePlayerName(state: GameState, playerId: string | undefined): string | undefined {
+  if (!playerId) return undefined
+  return state.players?.find(player => player.id === playerId)?.name
+}
+
+export default function MatchSummary({ state, meId, onExit }: Props) {
+  const winners = state.winners ?? []
+  const losers = state.losers ?? []
+  const resolvedWinnerId = state.winner_id ?? (winners.length === 1 ? winners[0] : undefined)
+  const meIsWinner = Boolean(meId && (resolvedWinnerId ? resolvedWinnerId === meId : winners.includes(meId)))
+
+  let subtitle: string
+  if (meIsWinner) {
+    subtitle = 'Вы победили!'
+  } else if (resolvedWinnerId) {
+    const winnerName = resolvePlayerName(state, resolvedWinnerId) ?? 'победитель'
+    subtitle = `Победил ${winnerName}`
+  } else if (winners.length > 1) {
+    const names = winners
+      .map(id => resolvePlayerName(state, id))
+      .filter((name): name is string => Boolean(name))
+    subtitle = names.length > 0 ? `Победили: ${names.join(', ')}` : 'Победители определены'
+  } else if (losers.length > 0) {
+    const name = resolvePlayerName(state, losers[0]) ?? 'противник'
+    subtitle = `Поражение для ${name}`
+  } else {
+    subtitle = 'Матч завершён'
+  }
+
+  const penaltyValues = (state.players ?? []).map(player => state.scores?.[player.id] ?? 0)
+  const scoreLine = penaltyValues.length > 0 ? penaltyValues.join(':') : null
+
+  const hasTotals = Boolean(state.player_totals && state.player_totals.length > 0)
+
+  return (
+    <div className="match-summary-screen">
+      <div className="match-summary-card">
+        <div className="match-summary-head">
+          <h1 className="match-summary-title">Матч завершён</h1>
+          <h2 className="match-summary-subtitle">{subtitle}</h2>
+          {scoreLine && (
+            <div className="match-summary-score">Со счётом: {scoreLine}</div>
+          )}
+          <p className="match-summary-note">12 штрафных очков — поражение.</p>
+        </div>
+        <button className="button primary match-summary-action" onClick={onExit}>
+          Вернуться на главный экран
+        </button>
+        {hasTotals && (
+          <div className="match-summary-table">
+            <ScoreBoard totals={state.player_totals} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -144,6 +144,17 @@ body, .app{
 .rules h3{ margin:0; font-size:var(--font-md); font-weight:700; }
 .rules ul{ margin:0; padding-left:18px; display:grid; gap:4px; }
 
+/* ======= MATCH SUMMARY ======= */
+.match-summary-screen{ min-height: calc(var(--app-vh-stable, 100vh) - 32px); display:flex; align-items:center; justify-content:center; padding:24px; }
+.match-summary-card{ width:min(100%, 420px); display:grid; gap:18px; padding:24px; border-radius:20px; background:var(--card); border:1px solid var(--border); box-shadow:0 12px 32px rgba(0,0,0,.18); text-align:center; }
+.match-summary-head{ display:grid; gap:6px; }
+.match-summary-title{ margin:0; font-size:var(--font-3xl); font-weight:800; }
+.match-summary-subtitle{ margin:0; font-size:var(--font-xl); font-weight:700; }
+.match-summary-score{ margin-top:6px; font-size:var(--font-lg); font-weight:700; }
+.match-summary-note{ margin:8px 0 0; font-size:var(--font-xs); color:var(--muted); }
+.match-summary-action{ justify-self:center; padding:12px 18px; font-size:var(--font-md); border-radius:14px; }
+.match-summary-table{ display:grid; }
+
 /* ======= LOBBY ======= */
 .lobby-wrap{ display:grid; gap: 12px; }
 .lobby-toolbar{ display:flex; gap: 8px; align-items:center; }


### PR DESCRIPTION
## Summary
- add a match result overlay that presents the winner, penalty totals, and return action
- route match-over game states to the summary screen and apply dedicated styling
- add a regression test to ensure the match ends when a player reaches twelve penalties

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55448f85c8332b9539a236cfd4bbf