### PR TITLE
Add trump suit icon display

### DIFF
--- a/frontend/src/components/SuitIcon.tsx
+++ b/frontend/src/components/SuitIcon.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+
+import type { Suit } from '../types'
+
+type Props = {
+  suit: Suit
+  size?: number
+  className?: string
+}
+
+const RED = '#D84C4C'
+const BLACK = '#1F1F1F'
+
+type SuitConfig = {
+  label: string
+  render: (color: string) => React.ReactNode
+  color: string
+}
+
+const SUIT_CONFIG: Record<Suit, SuitConfig> = {
+  '♠': {
+    label: 'Пики',
+    color: BLACK,
+    render: color => (
+      <>
+        <path
+          d="M16 2c-4.6 4.5-12 11-12 16 0 4.3 3.2 7 7 7h1l-2 7h12l-2-7h1c3.8 0 7-2.7 7-7 0-5-7.4-11.5-12-16z"
+          fill={color}
+        />
+        <path d="M12 25h8l-4 7z" fill={color} />
+      </>
+    ),
+  },
+  '♣': {
+    label: 'Трефы',
+    color: BLACK,
+    render: color => (
+      <>
+        <circle cx={16} cy={10} r={6} fill={color} />
+        <circle cx={10} cy={18} r={6} fill={color} />
+        <circle cx={22} cy={18} r={6} fill={color} />
+        <path d="M14 18h4v9h-4z" fill={color} />
+        <path d="M12 27h8l-4 5z" fill={color} />
+      </>
+    ),
+  },
+  '♥': {
+    label: 'Червы',
+    color: RED,
+    render: color => (
+      <path
+        d="M16 28s-12-7.6-12-16c0-4.4 3.6-8 8-8 2.8 0 5.3 1.6 6 4 .7-2.4 3.2-4 6-4 4.4 0 8 3.6 8 8 0 8.4-12 16-12 16z"
+        fill={color}
+      />
+    ),
+  },
+  '♦': {
+    label: 'Бубны',
+    color: RED,
+    render: color => <path d="M16 2 26 16 16 30 6 16z" fill={color} />,
+  },
+}
+
+export default function SuitIcon({ suit, size = 18, className }: Props) {
+  const config = SUIT_CONFIG[suit]
+  const composedClassName = ['suit-icon', className].filter(Boolean).join(' ')
+
+  return (
+    <svg
+      className={composedClassName}
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      role="img"
+      aria-label={config.label}
+      focusable="false"
+    >
+      <title>{config.label}</title>
+      {config.render(config.color)}
+    </svg>
+  )
+}

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import type { Card, CardColor, GameState, Player, Suit, TrickState } from '../types'
 import CardView from './CardView'
+import SuitIcon from './SuitIcon'
 
 type DragPreview = { cards: Card[]; valid: boolean } | null
 
@@ -147,7 +148,14 @@ export default function TableView({ state, meId, dragPreview, onDropPlay, cardAs
       <header className="table-header">
         <div className="table-meta-left">
           <span className="meta-chip">Раунд {state.round_number ?? 1}</span>
-          <span className="meta-chip">Козырь {state.trump_card ? state.trump_card.suit : '—'}</span>
+          <span className="meta-chip">
+            Козырь
+            {state.trump_card ? (
+              <SuitIcon suit={state.trump_card.suit} className="meta-chip-suit-icon" size={18} />
+            ) : (
+              '—'
+            )}
+          </span>
           <span className="meta-chip">Осталось карт: {state.deck_count}</span>
         </div>
         <div className="table-meta-right">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -326,6 +326,7 @@ body, .app{
 .settings-sub{ font-size:var(--font-2xs); color:var(--muted); }
 .settings-pills{ display:flex; flex-wrap:wrap; gap:8px; }
 .meta-chip{ display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); font-size:var(--font-2xs); font-weight:600; }
+.meta-chip .meta-chip-suit-icon{ width:18px; height:18px; }
 .game-settings .controls{ padding-top:4px; }
 
 .game-table{ display:grid; gap:12px; padding:12px; border:1px solid var(--border); border-radius:18px; background:var(--card); box-shadow:0 10px 24px rgba(0,0,0,.12); }


### PR DESCRIPTION
## Summary
- replace the trump suit text indicator with a dedicated SVG icon
- add a reusable suit icon component and adjust styling for consistent sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56baea1708332b908cc22b3754c4f