### PR TITLE
Improve trump badge contrast

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -148,7 +148,7 @@ export default function TableView({ state, meId, dragPreview, onDropPlay, cardAs
       <header className="table-header">
         <div className="table-meta-left">
           <span className="meta-chip">Раунд {state.round_number ?? 1}</span>
-          <span className="meta-chip">
+          <span className="meta-chip meta-chip-trump">
             Козырь
             {state.trump_card ? (
               <SuitIcon suit={state.trump_card.suit} className="meta-chip-suit-icon" size={18} />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -326,7 +326,9 @@ body, .app{
 .settings-sub{ font-size:var(--font-2xs); color:var(--muted); }
 .settings-pills{ display:flex; flex-wrap:wrap; gap:8px; }
 .meta-chip{ display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); font-size:var(--font-2xs); font-weight:600; }
+.meta-chip.meta-chip-trump{ background:#f7f7f7; color:#111; border-color:rgba(17,17,17,0.12); box-shadow:0 1px 3px rgba(15,17,21,0.16) inset, 0 1px 2px rgba(15,17,21,0.12); }
 .meta-chip .meta-chip-suit-icon{ width:18px; height:18px; }
+html[data-theme="dark"] .meta-chip.meta-chip-trump{ background:#ffffff; color:#111; border-color:rgba(17,17,17,0.16); box-shadow:0 1px 2px rgba(15,17,21,0.4); }
 .game-settings .controls{ padding-top:4px; }
 
 .game-table{ display:grid; gap:12px; padding:12px; border:1px solid var(--border); border-radius:18px; background:var(--card); box-shadow:0 10px 24px rgba(0,0,0,.12); }


### PR DESCRIPTION
## Summary
- add a dedicated style for the trump meta chip so it uses a light badge background
- ensure the trump badge uses the new style in the table header to keep the suit icon readable in dark mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57afc8b408332a6c25e8aea696ed8