### PR TITLE
Remove take value display from player's hand

### DIFF
--- a/frontend/src/components/Hand.tsx
+++ b/frontend/src/components/Hand.tsx
@@ -486,7 +486,6 @@ export default function Hand({
           {trick && (
             <>
               <span className="pill">Нужно: {trick.required_count}</span>
-              <span className="pill">Беру: {ownerLabel}</span>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- remove the "Беру" pill from the hand header so only the required count is shown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5801be1f8833293a85b6c8b870b91